### PR TITLE
Different columns fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Restructure HDFS files
 
-[![Build Status](https://travis-ci.org/RADAR-CNS/Restructure-HDFS-topic.svg?branch=master)](https://travis-ci.org/RADAR-CNS/Restructure-HDFS-topic)
+[![Build Status](https://travis-ci.org/RADAR-base/Restructure-HDFS-topic.svg?branch=master)](https://travis-ci.org/RADAR-base/Restructure-HDFS-topic)
 
 Data streamed to HDFS using the [RADAR HDFS sink connector](https://github.com/RADAR-CNS/RADAR-HDFS-Sink-Connector) is streamed to files based on sensor only. This package can transform that output to a local directory structure as follows: `userId/topic/date_hour.csv`. The date and hour is extracted from the `time` field of each record, and is formatted in UTC time.
 

--- a/src/main/java/org/radarcns/RestructureAvroRecords.java
+++ b/src/main/java/org/radarcns/RestructureAvroRecords.java
@@ -286,7 +286,7 @@ public class RestructureAvroRecords {
         // Write data
         int response = cache.writeRecord(outputPath, record);
 
-        if (response == FileCacheStore.CACHE_AND_NO_WRITE) {
+        if (response == FileCacheStore.CACHE_AND_NO_WRITE || response == FileCacheStore.NO_CACHE_AND_NO_WRITE) {
             // Write was unsuccessful due to different number of columns,
             // try again with new file name
             writeRecord(record, topicName, cache, ++suffix);

--- a/src/main/java/org/radarcns/RestructureAvroRecords.java
+++ b/src/main/java/org/radarcns/RestructureAvroRecords.java
@@ -266,11 +266,13 @@ public class RestructureAvroRecords {
         Date time = getDate(keyField, valueField);
         java.nio.file.Path outputFileName = createFilename(time);
 
-        // Clean Project id for use in final pathname
-        String projectId = keyField.get("projectId").toString().replaceAll("[^a-zA-Z0-9_-]+", "");
+        String projectId;
 
-        if (projectId == null) {
+        if(keyField.get("projectId") == null) {
             projectId = "unknown-project";
+        } else {
+            // Clean Project id for use in final pathname
+            projectId = keyField.get("projectId").toString().replaceAll("[^a-zA-Z0-9_-]+", "");
         }
 
         // Clean user id and create final output pathname

--- a/src/main/java/org/radarcns/RestructureAvroRecords.java
+++ b/src/main/java/org/radarcns/RestructureAvroRecords.java
@@ -240,7 +240,7 @@ public class RestructureAvroRecords {
             record = dataFileReader.next(record);
 
             // Get the fields
-            this.writeRecord(record, topicName, cache);
+            this.writeRecord(record, topicName, cache, 0);
         }
 
         // Write which file has been processed and update bins
@@ -253,7 +253,7 @@ public class RestructureAvroRecords {
         }
     }
 
-    private void writeRecord(GenericRecord record, String topicName, FileCacheStore cache)
+    private void writeRecord(GenericRecord record, String topicName, FileCacheStore cache, int suffix)
             throws IOException {
         GenericRecord keyField = (GenericRecord) record.get("key");
         GenericRecord valueField = (GenericRecord) record.get("value");
@@ -264,7 +264,7 @@ public class RestructureAvroRecords {
         }
 
         Date time = getDate(keyField, valueField);
-        java.nio.file.Path outputFileName = createFilename(time);
+        java.nio.file.Path outputFileName = createFilename(time, suffix);
 
         String projectId;
 
@@ -284,28 +284,43 @@ public class RestructureAvroRecords {
         java.nio.file.Path outputPath = userTopicDir.resolve(outputFileName);
 
         // Write data
-        cache.writeRecord(outputPath, record);
+        int response = cache.writeRecord(outputPath, record);
 
-        java.nio.file.Path schemaPath = userTopicDir.resolve(SCHEMA_OUTPUT_FILE_NAME);
-        if (!Files.exists(schemaPath)) {
-            try (Writer writer = Files.newBufferedWriter(schemaPath)) {
-                writer.write(record.getSchema().toString(true));
+        if (response == FileCacheStore.CACHE_AND_NO_WRITE) {
+            // Write was unsuccessful due to different number of columns,
+            // try again with new file name
+            writeRecord(record, topicName, cache, ++suffix);
+        } else {
+            // Write was successful, finalize the write
+            java.nio.file.Path schemaPath = userTopicDir.resolve(SCHEMA_OUTPUT_FILE_NAME);
+            if (!Files.exists(schemaPath)) {
+                try (Writer writer = Files.newBufferedWriter(schemaPath)) {
+                    writer.write(record.getSchema().toString(true));
+                }
             }
-        }
 
-        // Count data (binned and total)
-        bins.add(topicName, keyField.get("sourceId").toString(), time);
-        processedRecordsCount++;
+            // Count data (binned and total)
+            bins.add(topicName, keyField.get("sourceId").toString(), time);
+            processedRecordsCount++;
+        }
     }
 
-    private java.nio.file.Path createFilename(Date date) {
+    private java.nio.file.Path createFilename(Date date, int suffix) {
         if (date == null) {
             logger.warn("Time field of record valueField is not set");
             return Paths.get("unknown_date." + outputFileExtension);
         }
+
+        String finalSuffix;
+        if(suffix == 0) {
+            finalSuffix = "";
+        } else {
+            finalSuffix = "_" + suffix;
+        }
+
         // Make a timestamped filename YYYYMMDD_HH00.json
         String hourlyTimestamp = createHourTimestamp(date);
-        return Paths.get(hourlyTimestamp + "00." + outputFileExtension);
+        return Paths.get(hourlyTimestamp + "00" + finalSuffix +"." + outputFileExtension);
     }
 
     public static String createHourTimestamp(Date date) {

--- a/src/main/java/org/radarcns/util/CsvAvroConverter.java
+++ b/src/main/java/org/radarcns/util/CsvAvroConverter.java
@@ -59,6 +59,7 @@ public class CsvAvroConverter implements RecordConverter {
     private final ObjectWriter csvWriter;
     private final Map<String, Object> map;
     private final CsvGenerator generator;
+    private int numOfColumns;
 
     public CsvAvroConverter(CsvFactory factory, Writer writer, GenericRecord record, boolean writeHeader)
             throws IOException {
@@ -72,15 +73,22 @@ public class CsvAvroConverter implements RecordConverter {
         if (writeHeader) {
             schema = schema.withHeader();
         }
+        numOfColumns = schema.size();
         generator = factory.createGenerator(writer);
         csvWriter = new CsvMapper(factory).writer(schema);
     }
 
     @Override
-    public void writeRecord(GenericRecord record) throws IOException {
+    public boolean writeRecord(GenericRecord record) throws IOException {
         Map<String, Object> localMap = convertRecord(record);
+
+        if(localMap.size() > numOfColumns) {
+            // Cannot write to same file so return false
+            return false;
+        }
         csvWriter.writeValue(generator, localMap);
         localMap.clear();
+        return true;
     }
 
     public Map<String, Object> convertRecord(GenericRecord record) {

--- a/src/main/java/org/radarcns/util/CsvAvroConverter.java
+++ b/src/main/java/org/radarcns/util/CsvAvroConverter.java
@@ -30,6 +30,7 @@ import org.apache.avro.generic.GenericRecord;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.ByteBuffer;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,7 +60,7 @@ public class CsvAvroConverter implements RecordConverter {
     private final ObjectWriter csvWriter;
     private final Map<String, Object> map;
     private final CsvGenerator generator;
-    private int numOfColumns;
+    private final int numOfColumns;
 
     public CsvAvroConverter(CsvFactory factory, Writer writer, GenericRecord record, boolean writeHeader)
             throws IOException {
@@ -78,6 +79,12 @@ public class CsvAvroConverter implements RecordConverter {
         csvWriter = new CsvMapper(factory).writer(schema);
     }
 
+    /**
+     * Write AVRO record to CSV file.
+     * @param record the AVRO record to be written to CSV file
+     * @return true if write was successful, false if cannot write record to the current CSV file
+     * @throws IOException for other IO and Mapping errors
+     */
     @Override
     public boolean writeRecord(GenericRecord record) throws IOException {
         Map<String, Object> localMap = convertRecord(record);

--- a/src/main/java/org/radarcns/util/FileCache.java
+++ b/src/main/java/org/radarcns/util/FileCache.java
@@ -77,9 +77,10 @@ public class FileCache implements Closeable, Flushable, Comparable<FileCache> {
     }
 
     /** Write a record to the cache. */
-    public void writeRecord(GenericRecord record) throws IOException {
-        this.recordConverter.writeRecord(record);
+    public boolean writeRecord(GenericRecord record) throws IOException {
+        boolean result = this.recordConverter.writeRecord(record);
         lastUse = System.nanoTime();
+        return result;
     }
 
     @Override

--- a/src/main/java/org/radarcns/util/FileCache.java
+++ b/src/main/java/org/radarcns/util/FileCache.java
@@ -16,17 +16,11 @@
 
 package org.radarcns.util;
 
-import java.io.BufferedOutputStream;
-import java.io.Closeable;
-import java.io.FileOutputStream;
-import java.io.Flushable;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import javax.annotation.Nonnull;
 import org.apache.avro.generic.GenericRecord;
@@ -57,15 +51,19 @@ public class FileCache implements Closeable, Flushable, Comparable<FileCache> {
 
         OutputStream outFile = Files.newOutputStream(path,
                 StandardOpenOption.APPEND, StandardOpenOption.CREATE);
+        InputStream inputStream = new BufferedInputStream(Files.newInputStream(path));
         OutputStream bufOut = new BufferedOutputStream(outFile);
         if (gzip) {
             bufOut = new GZIPOutputStream(bufOut);
+            if (!fileIsNew) {
+                inputStream = new GZIPInputStream(inputStream);
+            }
         }
 
         this.writer = new OutputStreamWriter(bufOut);
 
-        try {
-            this.recordConverter = converterFactory.converterFor(writer, record, fileIsNew);
+        try (Reader reader = new InputStreamReader(inputStream)) {
+            this.recordConverter = converterFactory.converterFor(writer, record, fileIsNew, reader);
         } catch (IOException ex) {
             try {
                 writer.close();

--- a/src/main/java/org/radarcns/util/FileCache.java
+++ b/src/main/java/org/radarcns/util/FileCache.java
@@ -76,7 +76,12 @@ public class FileCache implements Closeable, Flushable, Comparable<FileCache> {
         }
     }
 
-    /** Write a record to the cache. */
+    /**
+     * Write a record to the cache.
+     * @param record AVRO record
+     * @return true or false based on {@link RecordConverter} write result
+     * @throws IOException
+     */
     public boolean writeRecord(GenericRecord record) throws IOException {
         boolean result = this.recordConverter.writeRecord(record);
         lastUse = System.nanoTime();

--- a/src/main/java/org/radarcns/util/FileCacheStore.java
+++ b/src/main/java/org/radarcns/util/FileCacheStore.java
@@ -61,7 +61,7 @@ public class FileCacheStore implements Flushable, Closeable {
      *
      * @param path file to append data to
      * @param record data
-     * @return integer according to one of the response codes.
+     * @return Integer value according to one of the response codes.
      * @throws IOException when failing to open a file or writing to it.
      */
     public int writeRecord(Path path, GenericRecord record) throws IOException {

--- a/src/main/java/org/radarcns/util/FileCacheStore.java
+++ b/src/main/java/org/radarcns/util/FileCacheStore.java
@@ -85,6 +85,8 @@ public class FileCacheStore implements Flushable, Closeable {
             if(cache.writeRecord(record)) {
                 return NO_CACHE_AND_WRITE;
             } else {
+                // The file path was not in cache but the file exists and this write is
+                // unsuccessful because of different number of columns
                 return NO_CACHE_AND_NO_WRITE;
             }
 

--- a/src/main/java/org/radarcns/util/JsonAvroConverter.java
+++ b/src/main/java/org/radarcns/util/JsonAvroConverter.java
@@ -42,7 +42,7 @@ public final class JsonAvroConverter implements RecordConverter {
 
     public static RecordConverterFactory getFactory() {
         JsonFactory factory = new JsonFactory();
-        return (writer, record, writeHeader) -> new JsonAvroConverter(factory, writer);
+        return (writer, record, writeHeader, reader) -> new JsonAvroConverter(factory, writer);
     }
 
     private final ObjectWriter jsonWriter;

--- a/src/main/java/org/radarcns/util/JsonAvroConverter.java
+++ b/src/main/java/org/radarcns/util/JsonAvroConverter.java
@@ -54,8 +54,9 @@ public final class JsonAvroConverter implements RecordConverter {
     }
 
     @Override
-    public void writeRecord(GenericRecord record) throws IOException {
+    public boolean writeRecord(GenericRecord record) throws IOException {
         jsonWriter.writeValue(generator, convertRecord(record));
+        return true;
     }
 
     public Map<String, Object> convertRecord(GenericRecord record) {

--- a/src/main/java/org/radarcns/util/RecordConverter.java
+++ b/src/main/java/org/radarcns/util/RecordConverter.java
@@ -17,11 +17,8 @@
 package org.radarcns.util;
 
 import java.io.Closeable;
-import java.io.File;
 import java.io.Flushable;
 import java.io.IOException;
-import java.nio.file.Path;
-import java.util.List;
 import java.util.Map;
 import org.apache.avro.generic.GenericRecord;
 

--- a/src/main/java/org/radarcns/util/RecordConverter.java
+++ b/src/main/java/org/radarcns/util/RecordConverter.java
@@ -27,6 +27,6 @@ import org.apache.avro.generic.GenericRecord;
 
 /** Converts a GenericRecord to Java primitives or writes it to file. */
 public interface RecordConverter extends Flushable, Closeable {
-    void writeRecord(GenericRecord record) throws IOException;
+    boolean writeRecord(GenericRecord record) throws IOException;
     Map<String, Object> convertRecord(GenericRecord record);
 }

--- a/src/main/java/org/radarcns/util/RecordConverterFactory.java
+++ b/src/main/java/org/radarcns/util/RecordConverterFactory.java
@@ -53,7 +53,7 @@ public interface RecordConverterFactory {
      * @return RecordConverter that is ready to be used
      * @throws IOException if the converter could not be created
      */
-    RecordConverter converterFor(Writer writer, GenericRecord record, boolean writeHeader) throws IOException;
+    RecordConverter converterFor(Writer writer, GenericRecord record, boolean writeHeader, Reader reader) throws IOException;
 
     default boolean hasHeader() {
         return false;

--- a/src/test/java/org/radarcns/util/CsvAvroConverterTest.java
+++ b/src/test/java/org/radarcns/util/CsvAvroConverterTest.java
@@ -116,8 +116,31 @@ public class CsvAvroConverterTest {
         Schema schemaB = SchemaBuilder.record("B").fields().name("b").type("string").noDefault().endRecord();
         GenericRecord recordB = new GenericRecordBuilder(schemaB).set("b", "something").build();
 
-        exception.expect(JsonMappingException.class);
-        converter.writeRecord(recordB);
+        /* Same number of columns but different schema, so CsvAvroConverter.write() will return false
+        signifying that a new CSV file must be used to write this record
+         */
+        assertFalse(converter.writeRecord(recordB));
+        System.out.println(writer.toString());
+    }
+
+
+    @Test
+    public void differentSchema2() throws IOException {
+        Schema schemaA = SchemaBuilder.record("A").fields().name("a").type("string").noDefault().name("b").type("string").noDefault().endRecord();
+        GenericRecord recordA = new GenericRecordBuilder(schemaA).set("a", "something").set("b", "2nd something").build();
+
+        StringWriter writer = new StringWriter();
+        RecordConverter converter = CsvAvroConverter.getFactory().converterFor(writer, recordA, true, new StringReader("test"));
+        converter.writeRecord(recordA);
+
+        Schema schemaB = SchemaBuilder.record("B").fields().name("b").type("string").noDefault().name("a").type("string").noDefault().endRecord();
+        GenericRecord recordB = new GenericRecordBuilder(schemaB).set("b", "something").set("a", "2nd something").build();
+
+        /* Same number of columns and same header but different order,
+        so CsvAvroConverter.write() will return false signifying that
+        a new CSV file must be used to write this record
+         */
+        assertFalse(converter.writeRecord(recordB));
         System.out.println(writer.toString());
     }
 

--- a/src/test/java/org/radarcns/util/CsvAvroConverterTest.java
+++ b/src/test/java/org/radarcns/util/CsvAvroConverterTest.java
@@ -24,19 +24,9 @@ import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Reader;
-import java.io.StringWriter;
-import java.io.Writer;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -77,7 +67,7 @@ public class CsvAvroConverterTest {
 
         StringWriter writer = new StringWriter();
         RecordConverterFactory factory = CsvAvroConverter.getFactory();
-        RecordConverter converter = factory.converterFor(writer, record, true);
+        RecordConverter converter = factory.converterFor(writer, record, true, new StringReader("test"));
 
         Map<String, Object> map = converter.convertRecord(record);
         List<String> keys = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i.some",
@@ -120,7 +110,7 @@ public class CsvAvroConverterTest {
         GenericRecord recordA = new GenericRecordBuilder(schemaA).set("a", "something").build();
 
         StringWriter writer = new StringWriter();
-        RecordConverter converter = CsvAvroConverter.getFactory().converterFor(writer, recordA, true);
+        RecordConverter converter = CsvAvroConverter.getFactory().converterFor(writer, recordA, true, new StringReader("test"));
         converter.writeRecord(recordA);
 
         Schema schemaB = SchemaBuilder.record("B").fields().name("b").type("string").noDefault().endRecord();
@@ -140,7 +130,7 @@ public class CsvAvroConverterTest {
                 .build();
 
         StringWriter writer = new StringWriter();
-        RecordConverter converter = CsvAvroConverter.getFactory().converterFor(writer, recordA, true);
+        RecordConverter converter = CsvAvroConverter.getFactory().converterFor(writer, recordA, true, new StringReader("test"));
         converter.writeRecord(recordA);
 
         Schema schemaB = SchemaBuilder.record("B").fields().name("b").type("string").noDefault().endRecord();

--- a/src/test/java/org/radarcns/util/FileCacheStoreTest.java
+++ b/src/test/java/org/radarcns/util/FileCacheStoreTest.java
@@ -57,23 +57,23 @@ public class FileCacheStoreTest {
 
         try (FileCacheStore cache = new FileCacheStore(csvFactory, 2, false, false)) {
             record = new GenericRecordBuilder(simpleSchema).set("a", "something").build();
-            assertFalse(cache.writeRecord(f1, record));
+            assertEquals(cache.writeRecord(f1, record), FileCacheStore.NO_CACHE_AND_WRITE);
             record = new GenericRecordBuilder(simpleSchema).set("a", "somethingElse").build();
-            assertTrue(cache.writeRecord(f1, record));
+            assertEquals(cache.writeRecord(f1, record), FileCacheStore.CACHE_AND_WRITE);
             record = new GenericRecordBuilder(simpleSchema).set("a", "something").build();
-            assertFalse(cache.writeRecord(f2, record));
+            assertEquals(cache.writeRecord(f2, record), FileCacheStore.NO_CACHE_AND_WRITE);
             record = new GenericRecordBuilder(simpleSchema).set("a", "third").build();
-            assertTrue(cache.writeRecord(f1, record));
+            assertEquals(cache.writeRecord(f1, record), FileCacheStore.CACHE_AND_WRITE);
             record = new GenericRecordBuilder(simpleSchema).set("a", "f3").build();
-            assertFalse(cache.writeRecord(f3, record));
+            assertEquals(cache.writeRecord(f3, record), FileCacheStore.NO_CACHE_AND_WRITE);
             record = new GenericRecordBuilder(simpleSchema).set("a", "f2").build();
-            assertFalse(cache.writeRecord(f2, record));
+            assertEquals(cache.writeRecord(f2, record), FileCacheStore.NO_CACHE_AND_WRITE);
             record = new GenericRecordBuilder(simpleSchema).set("a", "f3").build();
-            assertTrue(cache.writeRecord(f3, record));
+            assertEquals(cache.writeRecord(f3, record), FileCacheStore.CACHE_AND_WRITE);
             record = new GenericRecordBuilder(simpleSchema).set("a", "f4").build();
-            assertFalse(cache.writeRecord(f4, record));
+            assertEquals(cache.writeRecord(f4, record), FileCacheStore.NO_CACHE_AND_WRITE);
             record = new GenericRecordBuilder(simpleSchema).set("a", "f3").build();
-            assertTrue(cache.writeRecord(f3, record));
+            assertEquals(cache.writeRecord(f3, record), FileCacheStore.CACHE_AND_WRITE);
         }
 
         assertEquals("a\nsomething\nsomethingElse\nthird\n", new String(Files.readAllBytes(f1)));

--- a/src/test/java/org/radarcns/util/FileCacheStoreTest.java
+++ b/src/test/java/org/radarcns/util/FileCacheStoreTest.java
@@ -17,10 +17,7 @@
 package org.radarcns.util;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -44,6 +41,7 @@ public class FileCacheStoreTest {
         Path f3 = folder.newFile().toPath();
         Path d4 = folder.newFolder().toPath();
         Path f4 = d4.resolve("f4.txt");
+        Path newFile = folder.newFile().toPath();
 
         Files.delete(f1);
         Files.delete(d4);
@@ -82,12 +80,16 @@ public class FileCacheStoreTest {
             record = new GenericRecordBuilder(conflictSchema).set("a", "f3"). set("b", "conflict").build();
             assertEquals(cache.writeRecord(f3, record), FileCacheStore.CACHE_AND_NO_WRITE);
             record = new GenericRecordBuilder(conflictSchema).set("a", "f1"). set("b", "conflict").build();
-            assertEquals(cache.writeRecord(f1, record), FileCacheStore.NO_CACHE_AND_WRITE);
+            // Cannot write to file even though the file is not in cache since schema is different
+            assertEquals(cache.writeRecord(f1, record), FileCacheStore.NO_CACHE_AND_NO_WRITE);
+            // Can write the same record to a new file
+            assertEquals(cache.writeRecord(newFile, record), FileCacheStore.NO_CACHE_AND_WRITE);
         }
 
-        assertEquals("a\nsomething\nsomethingElse\nthird\nf1,conflict\n", new String(Files.readAllBytes(f1)));
+        assertEquals("a\nsomething\nsomethingElse\nthird\n", new String(Files.readAllBytes(f1)));
         assertEquals("a\nsomething\nf2\n", new String(Files.readAllBytes(f2)));
         assertEquals("a\nf3\nf3\nf3\n", new String(Files.readAllBytes(f3)));
         assertEquals("a\nf4\n", new String(Files.readAllBytes(f4)));
+        assertEquals("a,b\nf1,conflict\n", new String(Files.readAllBytes(newFile)));
     }
 }

--- a/src/test/java/org/radarcns/util/JsonAvroConverterTest.java
+++ b/src/test/java/org/radarcns/util/JsonAvroConverterTest.java
@@ -22,11 +22,8 @@ import static org.radarcns.util.CsvAvroConverterTest.writeTestNumbers;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.StringWriter;
+
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -55,7 +52,7 @@ public class JsonAvroConverterTest {
         JsonDecoder decoder = DecoderFactory.get().jsonDecoder(schema, getClass().getResourceAsStream("full.json"));
         GenericRecord record = reader.read(null, decoder);
 
-        Map<String, Object> map = JsonAvroConverter.getFactory().converterFor(new StringWriter(), record, false).convertRecord(record);
+        Map<String, Object> map = JsonAvroConverter.getFactory().converterFor(new StringWriter(), record, false, new StringReader("test")).convertRecord(record);
         ObjectWriter writer = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT).writer();
         String result = writer.writeValueAsString(map);
 


### PR DESCRIPTION
- Closes #15 
- ~~Depends on #17~~
- If different records in the same topic have different number or different names or different order of columns, then it just creates a new CSV file to write the record. For other issues of conflicting columns, it throws an exception since we don't want it to write wrong format data to a topic's csv file. This particularly fixes the extraction of Questionnaire records which have variable number of columns since it contains an array of answers whose size can vary with each record.
- The newly created File has a suffix starting with 1. So if a file was named `20180221_1800.csv`, then subsequent files for the same topic and same time but different columns will be named `20180221_1800_1.csv`, `20180221_1800_2.csv` and so on
- If the CSV file already exists but is not present in the cache, then read the schema from CSV file to avoid any clashes with current record.