### PR TITLE
Run the HDFS restructuring as a service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+# Force use of dist where oraclejdk8 is supported
+dist: trusty
 jdk:
   - oraclejdk8
 sudo: false

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ By default, files records are not deduplicated after writing. To enable this beh
 
 To set the output user ID and group ID, specify the `-p local-uid=123` and `-p local-gid=12` properties.
 
+To run the output generator as a service that will regularly poll the HDFS directory, add the `--service` flag and optionally the `--interval` flag to adjust the polling interval.
+
 ## Extending the connector
 
 To implement alternative storage paths, storage drivers or storage formats, put your custom JAR in

--- a/src/main/java/org/radarcns/hdfs/util/commandline/CommandLineArgs.java
+++ b/src/main/java/org/radarcns/hdfs/util/commandline/CommandLineArgs.java
@@ -96,6 +96,12 @@ public class CommandLineArgs {
     @Parameter(names = {"--exclude-topic"}, description = "Topic to exclude when processing the records. Can be supplied more than once to exclude multiple topics.")
     public List<String> excludeTopics = new ArrayList<>();
 
+    @Parameter(names = {"-s", "--service"}, description = "Run the output generation as a service")
+    public boolean asService = false;
+
+    @Parameter(names = {"-i", "--interval"}, description = "Polling interval when running as a service (seconds)")
+    public int pollInterval = 3600;
+
     public static <T> T nonNullOrDefault(T value, Supplier<T> defaultValue) {
         return value != null ? value : defaultValue.get();
     }

--- a/src/main/java/org/radarcns/hdfs/util/commandline/CommandLineArgs.java
+++ b/src/main/java/org/radarcns/hdfs/util/commandline/CommandLineArgs.java
@@ -96,7 +96,7 @@ public class CommandLineArgs {
     @Parameter(names = {"--exclude-topic"}, description = "Topic to exclude when processing the records. Can be supplied more than once to exclude multiple topics.")
     public List<String> excludeTopics = new ArrayList<>();
 
-    @Parameter(names = {"-s", "--service"}, description = "Run the output generation as a service")
+    @Parameter(names = {"-S", "--service"}, description = "Run the output generation as a service")
     public boolean asService = false;
 
     @Parameter(names = {"-i", "--interval"}, description = "Polling interval when running as a service (seconds)")


### PR DESCRIPTION
This gives slightly less control about what topic to parse at what time, but it avoids needing systemd to control when output is generated.

Accompanying docker-compose fragment could be:
```yaml
radar-output:
  image: radarbase/radar-hdfs-restructure:0.5.7-SNAPSHOT
  restart: always
  networks:
    - hadoop
  depends_on:
    - hdfs-namenode-1
    - hdfs-datanode-1
    - hdfs-datanode-2
    - hdfs-datanode-3
  volumes:
    - ${RESTRUCTURE_OUTPUT_DIR}:/output
  command:
    - --compression
    - gzip
    - --deduplicate
    - --num-threads
    - ${RESTRUCTURE_NUM_THREADS}
    - -n
    - hdfs-namenode-1
    - -o
    - /output
    - --tmp-dir
    - /output/+tmp
    - -S
    - -i
    - "300"
    - /topicAndroidNew
```