### PR TITLE
Enable delete on old files

### DIFF
--- a/src/main/java/org/radarbase/output/Application.kt
+++ b/src/main/java/org/radarbase/output/Application.kt
@@ -127,6 +127,11 @@ class Application(
                         numberFormat.format(restructure.processedFileCount),
                         numberFormat.format(restructure.processedRecordsCount),
                         timeStart.durationSince().format())
+                if (restructure.deletedFileCount.sum() > 0) {
+                    logger.info("Deleted {} old files", numberFormat.format(restructure.deletedFileCount))
+                } else {
+                    logger.info("No files were deleted")
+                }
             }
         } catch (ex: Exception) {
             logger.error("Failed to process records", ex)

--- a/src/main/java/org/radarbase/output/config/RestructureConfig.kt
+++ b/src/main/java/org/radarbase/output/config/RestructureConfig.kt
@@ -90,7 +90,9 @@ data class ServiceConfig(
         /** Whether to enable the service mode of this application. */
         val enable: Boolean,
         /** Polling interval in seconds. */
-        val interval: Long = 3600)
+        val interval: Long = 3600,
+        /** Age in days after an avro file can be removed. Ignored if not strictly positive. */
+        val deleteAfterDays: Int = -1)
 
 data class WorkerConfig(
         /** Number of threads to use for processing files. */
@@ -167,7 +169,12 @@ data class TopicConfig(
         /** Topic-specific deduplication handling. */
         val deduplication: DeduplicationConfig? = null,
         /** Whether to exclude the topic from being processed. */
-        val exclude: Boolean = false) {
+        val exclude: Boolean = false,
+        /**
+         * Whether to exclude the topic from being deleted, if this configuration has been set
+         * in the service.
+         */
+        val excludeFromDelete: Boolean = false) {
     fun deduplication(deduplicationDefault: DeduplicationConfig): DeduplicationConfig {
         return deduplication
                 ?.run { if (enable == null) copy(enable = deduplicationDefault.enable) else this }

--- a/src/main/java/org/radarbase/output/kafka/KafkaStorage.kt
+++ b/src/main/java/org/radarbase/output/kafka/KafkaStorage.kt
@@ -7,7 +7,7 @@ import java.nio.file.Path
 interface KafkaStorage {
     fun reader(): KafkaStorageReader
     fun list(path: Path): Sequence<SimpleFileStatus>
-
+    fun delete(path: Path)
 
     interface KafkaStorageReader: Closeable {
         fun newInput(file: TopicFile): SeekableInput

--- a/src/main/java/org/radarbase/output/kafka/S3KafkaStorage.kt
+++ b/src/main/java/org/radarbase/output/kafka/S3KafkaStorage.kt
@@ -21,6 +21,10 @@ class S3KafkaStorage(
                 SimpleFileStatus(Paths.get(item.objectName()), item.isDir, item.lastModified().toInstant())
             }
 
+    override fun delete(path: Path) {
+        s3Client.removeObject(bucket, path.toString())
+    }
+
     override fun reader(): KafkaStorage.KafkaStorageReader = S3KafkaStorageReader()
 
     private inner class S3KafkaStorageReader: KafkaStorage.KafkaStorageReader {

--- a/src/main/java/org/radarbase/output/kafka/S3KafkaStorage.kt
+++ b/src/main/java/org/radarbase/output/kafka/S3KafkaStorage.kt
@@ -18,7 +18,7 @@ class S3KafkaStorage(
             .asSequence()
             .map {
                 val item = it.get()
-                SimpleFileStatus(Paths.get(item.objectName()), item.isDir)
+                SimpleFileStatus(Paths.get(item.objectName()), item.isDir, item.lastModified().toInstant())
             }
 
     override fun reader(): KafkaStorage.KafkaStorageReader = S3KafkaStorageReader()

--- a/src/main/java/org/radarbase/output/kafka/TopicFileList.kt
+++ b/src/main/java/org/radarbase/output/kafka/TopicFileList.kt
@@ -2,6 +2,7 @@ package org.radarbase.output.kafka
 
 import org.radarbase.output.accounting.OffsetRange
 import java.nio.file.Path
+import java.time.Instant
 
 data class TopicFileList(val topic: String, val files: List<TopicFile>) {
     val numberOfOffsets: Long = this.files.stream()
@@ -11,9 +12,9 @@ data class TopicFileList(val topic: String, val files: List<TopicFile>) {
     val numberOfFiles: Int = this.files.size
 }
 
-data class TopicFile(val topic: String, val path: Path) {
+data class TopicFile(val topic: String, val path: Path, val lastModified: Instant) {
     val range: OffsetRange = OffsetRange.parseFilename(path.fileName.toString())
     val size: Long = 1 + range.offsetTo - range.offsetFrom
 }
 
-data class SimpleFileStatus(val path: Path, val isDirectory: Boolean)
+data class SimpleFileStatus(val path: Path, val isDirectory: Boolean, val lastModified: Instant)

--- a/src/main/java/org/radarbase/output/worker/RadarKafkaRestructure.kt
+++ b/src/main/java/org/radarbase/output/worker/RadarKafkaRestructure.kt
@@ -107,7 +107,7 @@ class RadarKafkaRestructure(
 
                     val statistics = startWorker(topic, topicPath, accountant, seenFiles)
                     if (deleteThreshold != null && topic !in excludeDeleteTopics) {
-                        deleteOldFiles(topic, topicPath, seenFiles)
+                        statistics.deleteCount = deleteOldFiles(topic, topicPath, seenFiles)
                     }
                     statistics
                 }

--- a/src/main/java/org/radarbase/output/worker/RestructureWorker.kt
+++ b/src/main/java/org/radarbase/output/worker/RestructureWorker.kt
@@ -8,7 +8,6 @@ import org.apache.avro.generic.GenericRecord
 import org.radarbase.output.FileStoreFactory
 import org.radarbase.output.accounting.Accountant
 import org.radarbase.output.accounting.OffsetRangeSet
-import org.radarbase.output.accounting.TopicPartition
 import org.radarbase.output.kafka.KafkaStorage
 import org.radarbase.output.kafka.TopicFile
 import org.radarbase.output.kafka.TopicFileList
@@ -27,7 +26,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.roundToLong
 
 internal class RestructureWorker(
-        private val pathFactory: RecordPathFactory,
         storage: KafkaStorage,
         private val accountant: Accountant,
         fileStoreFactory: FileStoreFactory,
@@ -36,6 +34,7 @@ internal class RestructureWorker(
     var processedFileCount: Long = 0
     var processedRecordsCount: Long = 0
     private val reader = storage.reader()
+    private val pathFactory: RecordPathFactory = fileStoreFactory.pathFactory
 
     private val cacheStore = fileStoreFactory.newFileCacheStore(accountant)
 


### PR DESCRIPTION
This will ensure that old already processed HDFS/S3 files are removed without needing to process them again. It will free up disk space for output that has landed in a different format anyway.