### PR TITLE
Process overlapping offsets if a file is updated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.dataformat' , name: 'jackson-dataformat-yaml', version: jacksonVersion
     implementation group: 'com.fasterxml.jackson.dataformat' , name: 'jackson-dataformat-csv', version: jacksonVersion
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: jacksonVersion
     implementation "redis.clients:jedis:$jedisVersion"
 
     implementation group: 'com.beust', name: 'jcommander', version: jCommanderVersion
@@ -137,6 +138,9 @@ task integrationTest(type: Test) {
     useJUnitPlatform()
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
+    testLogging {
+        setExceptionFormat("full")
+    }
     shouldRunAfter test
 }
 

--- a/src/integrationTest/java/org/radarbase/output/accounting/OffsetRangeRedisTest.kt
+++ b/src/integrationTest/java/org/radarbase/output/accounting/OffsetRangeRedisTest.kt
@@ -1,10 +1,10 @@
 package org.radarbase.output.accounting
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.radarbase.output.accounting.OffsetRedisPersistence.Companion.redisOffsetReader
 import redis.clients.jedis.JedisPool
 import java.io.IOException
 import java.nio.file.Path
@@ -75,7 +75,7 @@ class OffsetRangeRedisTest {
         }
 
         redisPool.resource.use { redis ->
-            val range = jacksonObjectMapper().readValue(redis.get(testFile.toString()), OffsetRedisPersistence.Companion.RedisOffsetRangeSet::class.java)
+            val range = redisOffsetReader.readValue<OffsetRedisPersistence.Companion.RedisOffsetRangeSet>(redis.get(testFile.toString()))
             assertEquals(OffsetRedisPersistence.Companion.RedisOffsetRangeSet(listOf(
                     OffsetRedisPersistence.Companion.RedisOffsetIntervals("a", 0, listOf(
                             OffsetRangeSet.Range(0, 2, lastModified),

--- a/src/integrationTest/java/org/radarbase/output/accounting/OffsetRangeRedisTest.kt
+++ b/src/integrationTest/java/org/radarbase/output/accounting/OffsetRangeRedisTest.kt
@@ -9,11 +9,13 @@ import redis.clients.jedis.JedisPool
 import java.io.IOException
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.time.Instant
 
 class OffsetRangeRedisTest {
     private lateinit var testFile: Path
     private lateinit var redisPool: JedisPool
     private lateinit var offsetPersistence: OffsetPersistenceFactory
+    private val lastModified = Instant.now()
 
     @BeforeEach
     @Throws(IOException::class)
@@ -47,37 +49,37 @@ class OffsetRangeRedisTest {
     @Throws(IOException::class)
     fun write() {
         offsetPersistence.writer(testFile).use { rangeFile ->
-            rangeFile.add(OffsetRange.parseFilename("a+0+0+1"))
-            rangeFile.add(OffsetRange.parseFilename("a+0+1+2"))
+            rangeFile.add(TopicPartitionOffsetRange.parseFilename("a+0+0+1", lastModified))
+            rangeFile.add(TopicPartitionOffsetRange.parseFilename("a+0+1+2", lastModified))
         }
 
         val set = offsetPersistence.read(testFile)
         assertNotNull(set)
         requireNotNull(set)
-        assertTrue(set.contains(OffsetRange.parseFilename("a+0+0+1")))
-        assertTrue(set.contains(OffsetRange.parseFilename("a+0+1+2")))
-        assertTrue(set.contains(OffsetRange.parseFilename("a+0+0+2")))
-        assertFalse(set.contains(OffsetRange.parseFilename("a+0+0+3")))
-        assertFalse(set.contains(OffsetRange.parseFilename("a+0+2+3")))
-        assertFalse(set.contains(OffsetRange.parseFilename("a+1+0+1")))
-        assertFalse(set.contains(OffsetRange.parseFilename("b+0+0+1")))
+        assertTrue(set.contains(TopicPartitionOffsetRange.parseFilename("a+0+0+1", lastModified)))
+        assertTrue(set.contains(TopicPartitionOffsetRange.parseFilename("a+0+1+2", lastModified)))
+        assertTrue(set.contains(TopicPartitionOffsetRange.parseFilename("a+0+0+2", lastModified)))
+        assertFalse(set.contains(TopicPartitionOffsetRange.parseFilename("a+0+0+3", lastModified)))
+        assertFalse(set.contains(TopicPartitionOffsetRange.parseFilename("a+0+2+3", lastModified)))
+        assertFalse(set.contains(TopicPartitionOffsetRange.parseFilename("a+1+0+1", lastModified)))
+        assertFalse(set.contains(TopicPartitionOffsetRange.parseFilename("b+0+0+1", lastModified)))
     }
 
     @Test
     @Throws(IOException::class)
     fun cleanUp() {
         offsetPersistence.writer(testFile).use { rangeFile ->
-            rangeFile.add(OffsetRange.parseFilename("a+0+0+1"))
-            rangeFile.add(OffsetRange.parseFilename("a+0+1+2"))
-            rangeFile.add(OffsetRange.parseFilename("a+0+4+4"))
+            rangeFile.add(TopicPartitionOffsetRange.parseFilename("a+0+0+1", lastModified))
+            rangeFile.add(TopicPartitionOffsetRange.parseFilename("a+0+1+2", lastModified))
+            rangeFile.add(TopicPartitionOffsetRange.parseFilename("a+0+4+4", lastModified))
         }
 
         redisPool.resource.use { redis ->
-            val range = jacksonObjectMapper().readValue(redis.get(testFile.toString()), OffsetRangeSet.OffsetRangeList::class.java)
-            assertEquals(OffsetRangeSet.OffsetRangeList(listOf(
-                    OffsetRangeSet.OffsetRangeList.TopicPartitionRange("a", 0, listOf(
-                            OffsetRangeSet.Range(0, 2),
-                            OffsetRangeSet.Range(4, 4)))
+            val range = jacksonObjectMapper().readValue(redis.get(testFile.toString()), OffsetRedisPersistence.Companion.RedisOffsetRangeSet::class.java)
+            assertEquals(OffsetRedisPersistence.Companion.RedisOffsetRangeSet(listOf(
+                    OffsetRedisPersistence.Companion.RedisOffsetIntervals("a", 0, listOf(
+                            OffsetRangeSet.Range(0, 2, lastModified),
+                            OffsetRangeSet.Range(4, 4, lastModified)))
             )), range)
         }
 

--- a/src/main/java/org/radarbase/output/accounting/Accountant.kt
+++ b/src/main/java/org/radarbase/output/accounting/Accountant.kt
@@ -25,6 +25,7 @@ import java.io.Flushable
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Paths
+import java.time.Instant
 
 open class Accountant @Throws(IOException::class)
 constructor(factory: FileStoreFactory, topic: String) : Flushable, Closeable {
@@ -88,11 +89,11 @@ constructor(factory: FileStoreFactory, topic: String) : Flushable, Closeable {
         internal val offsets: OffsetRangeSet = OffsetRangeSet { DirectFunctionalValue(it) }
 
         fun add(transaction: Transaction) = time("accounting.add") {
-            offsets.add(transaction.topicPartition, transaction.offset)
+            offsets.add(transaction.topicPartition, transaction.offset, transaction.lastModified)
         }
     }
 
-    class Transaction(val topicPartition: TopicPartition, internal var offset: Long)
+    class Transaction(val topicPartition: TopicPartition, internal var offset: Long, internal val lastModified: Instant)
 
     companion object {
         private val logger = LoggerFactory.getLogger(Accountant::class.java)

--- a/src/main/java/org/radarbase/output/accounting/OffsetIntervals.kt
+++ b/src/main/java/org/radarbase/output/accounting/OffsetIntervals.kt
@@ -1,0 +1,159 @@
+package org.radarbase.output.accounting
+
+import com.almworks.integers.LongArray
+import java.time.Instant
+
+class OffsetIntervals {
+    private val offsetsFrom: LongArray
+    private val offsetsTo: LongArray
+    private val lastProcessed: MutableList<Instant>
+
+    constructor() {
+        offsetsFrom = LongArray(8)
+        offsetsTo = LongArray(8)
+        lastProcessed = ArrayList(8)
+    }
+
+    constructor(other: OffsetIntervals) {
+        offsetsFrom = LongArray(other.offsetsFrom)
+        offsetsTo = LongArray(other.offsetsTo)
+        lastProcessed = ArrayList(other.lastProcessed)
+    }
+
+    fun contains(range: OffsetRangeSet.Range): Boolean {
+        //  -index-1 if not found
+        val searchIndex = offsetsFrom.binarySearch(range.from)
+        val index = if (searchIndex >= 0) searchIndex else -searchIndex - 2
+        return (index >= 0
+                && range.to <= offsetsTo[index]
+                && range.lastProcessed <= lastProcessed[index])
+    }
+
+    fun contains(offset: Long, lastModified: Instant): Boolean {
+        //  -index-1 if not found
+        val searchIndex = offsetsFrom.binarySearch(offset)
+        if (searchIndex >= 0) {
+            return lastModified <= lastProcessed[searchIndex]
+        }
+
+        val indexBefore = -searchIndex - 2
+        return (indexBefore >= 0
+                && offset <= offsetsTo[indexBefore]
+                && lastModified <= lastProcessed[indexBefore])
+    }
+
+    fun add(offset: Long, lastModified: Instant) {
+        var index = offsetsFrom.binarySearch(offset)
+        if (index >= 0) {
+            lastProcessed[index] = max(lastProcessed[index], lastModified)
+            return
+        }
+        // index where this range would be entered
+        index = -index - 1
+
+        if (index > 0 && offset == offsetsTo[index - 1] + 1) {
+            // concat with range before it and possibly stream afterwards
+            offsetsTo[index - 1] = offset
+            lastProcessed[index - 1] = max(lastProcessed[index - 1], lastModified)
+            if (index < offsetsFrom.size() && offset == offsetsFrom[index] - 1) {
+                offsetsTo[index - 1] = offsetsTo[index]
+                lastProcessed[index - 1] = max(lastProcessed[index - 1], lastProcessed[index])
+                offsetsFrom.removeAt(index)
+                offsetsTo.removeAt(index)
+                lastProcessed.removeAt(index)
+            }
+        } else if (index >= offsetsFrom.size() || offset < offsetsFrom[index] - 1) {
+            // cannot concat, enter new range
+            offsetsFrom.insert(index, offset)
+            offsetsTo.insert(index, offset)
+            if (index >= offsetsFrom.size()) {
+                lastProcessed.add(lastModified)
+            } else {
+                lastProcessed.add(index, lastModified)
+            }
+        } else {
+            // concat with the stream after it
+            offsetsFrom[index] = offset
+            lastProcessed[index] = max(lastProcessed[index], lastModified)
+        }
+    }
+
+    fun add(range: OffsetRangeSet.Range) {
+        val (from, to, lastModified) = range
+        var index = offsetsFrom.binarySearch(from)
+        if (index < 0) {
+            // index where this range would be entered
+            index = -index - 1
+
+            if (index > 0 && from <= offsetsTo[index - 1] + 1) {
+                // concat with range before it and possibly stream afterwards
+                index--
+                lastProcessed[index] = max(lastProcessed[index], lastModified)
+            } else if (index >= offsetsFrom.size() || to < offsetsFrom[index] - 1) {
+                // cannot concat, enter new range
+                offsetsFrom.insert(index, from)
+                offsetsTo.insert(index, to)
+                if (index >= offsetsFrom.size()) {
+                    lastProcessed.add(lastModified)
+                } else {
+                    lastProcessed.add(index, lastModified)
+                }
+                return
+            } else {
+                // concat with the stream after it
+                offsetsFrom[index] = from
+                lastProcessed[index] = max(lastProcessed[index], lastModified)
+            }
+        } else {
+            lastProcessed[index] = max(lastProcessed[index], lastModified)
+        }
+
+        if (to <= offsetsTo[index]) {
+            return
+        }
+
+        offsetsTo[index] = to
+
+        var overlapIndex = index + 1
+        val startIndex = overlapIndex
+        var maxProcessed = lastProcessed[index]
+
+        while (overlapIndex < offsetsTo.size() && to >= offsetsTo[overlapIndex]) {
+            maxProcessed = max(maxProcessed, lastProcessed[overlapIndex])
+            overlapIndex++
+        }
+        if (overlapIndex < offsetsFrom.size() && to >= offsetsFrom[overlapIndex] - 1) {
+            offsetsTo[index] = offsetsTo[overlapIndex]
+            maxProcessed = max(maxProcessed, lastProcessed[overlapIndex])
+            overlapIndex++
+        }
+        if (overlapIndex != startIndex) {
+            offsetsFrom.removeRange(startIndex, overlapIndex)
+            offsetsTo.removeRange(startIndex, overlapIndex)
+            lastProcessed.subList(startIndex, overlapIndex).clear()
+            lastProcessed[index] = maxProcessed
+        }
+    }
+
+    fun forEach(
+            action: (offsetFrom: Long, offsetTo: Long, lastModified: Instant) -> Unit
+    ) = repeat(lastProcessed.size) { i ->
+        action(offsetsFrom[i], offsetsTo[i], lastProcessed[i])
+    }
+
+    fun toList(): List<OffsetRangeSet.Range> = List(lastProcessed.size) { i ->
+        OffsetRangeSet.Range(offsetsFrom[i], offsetsTo[i], lastProcessed[i])
+    }
+
+    fun size(): Int = offsetsFrom.size()
+
+    override fun toString(): String {
+        return ("[" + lastProcessed.indices.joinToString(", ") { i ->
+            "(${offsetsFrom[i]} - ${offsetsTo[i]}, ${lastProcessed[i]})"
+        } + "]")
+    }
+
+    companion object {
+        private fun <T: Comparable<T>> max(a: T, b: T): T = if (a >= b) a else b
+    }
+}

--- a/src/main/java/org/radarbase/output/accounting/OffsetPersistenceFactory.kt
+++ b/src/main/java/org/radarbase/output/accounting/OffsetPersistenceFactory.kt
@@ -44,7 +44,7 @@ interface OffsetPersistenceFactory {
         /**
          * Add a single offset range to the writer.
          */
-        fun add(range: OffsetRange) = offsets.add(range)
+        fun add(range: TopicPartitionOffsetRange) = offsets.add(range)
 
         /**
          * Add all elements in given offset range set to the writer.

--- a/src/main/java/org/radarbase/output/accounting/TopicPartition.kt
+++ b/src/main/java/org/radarbase/output/accounting/TopicPartition.kt
@@ -24,9 +24,6 @@ data class TopicPartition(val topic: String, val partition: Int) : Comparable<To
 
     override fun hashCode() = hash
 
-    override fun compareTo(other: TopicPartition): Int = comparator.compare(this, other)
-
-    companion object {
-        val comparator = compareBy(TopicPartition::topic, TopicPartition::partition)
-    }
+    override fun compareTo(other: TopicPartition) = compareValuesBy(this, other,
+            TopicPartition::topic, TopicPartition::partition)
 }

--- a/src/main/java/org/radarbase/output/kafka/TopicFileList.kt
+++ b/src/main/java/org/radarbase/output/kafka/TopicFileList.kt
@@ -1,20 +1,17 @@
 package org.radarbase.output.kafka
 
-import org.radarbase.output.accounting.OffsetRange
+import org.radarbase.output.accounting.TopicPartitionOffsetRange
 import java.nio.file.Path
 import java.time.Instant
 
 data class TopicFileList(val topic: String, val files: List<TopicFile>) {
-    val numberOfOffsets: Long = this.files.stream()
-            .mapToLong { it.size }
-            .sum()
-
+    val numberOfOffsets: Long = this.files.fold(0L) { sum, f -> sum + f.size }
     val numberOfFiles: Int = this.files.size
 }
 
 data class TopicFile(val topic: String, val path: Path, val lastModified: Instant) {
-    val range: OffsetRange = OffsetRange.parseFilename(path.fileName.toString())
-    val size: Long = 1 + range.offsetTo - range.offsetFrom
+    val range: TopicPartitionOffsetRange = TopicPartitionOffsetRange.parseFilename(path.fileName.toString(), lastModified)
+    val size: Long = range.range.size
 }
 
 data class SimpleFileStatus(val path: Path, val isDirectory: Boolean, val lastModified: Instant)

--- a/src/main/java/org/radarbase/output/worker/RadarKafkaRestructure.kt
+++ b/src/main/java/org/radarbase/output/worker/RadarKafkaRestructure.kt
@@ -30,9 +30,6 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.LongAdder
-import java.util.stream.Collectors
-import java.util.stream.Stream
-import kotlin.streams.asStream
 
 /**
  * Performs the following actions
@@ -149,7 +146,7 @@ class RadarKafkaRestructure(
             .filter { f -> f.lastModified.isBefore(deleteThreshold) &&
                     // ensure that there is a file with a larger offset also
                     // processed, so the largest offset is never removed.
-                    seenFiles.contains(f.range.copy(offsetTo = f.range.offsetTo + 1)) }
+                    seenFiles.contains(f.range.copy(range = f.range.range.copy(to = f.range.range.to + 1))) }
             .take(maxFilesPerTopic)
             .map { kafkaStorage.delete(it.path) }
             .count()

--- a/src/test/java/org/radarbase/output/OffsetRangeFileTest.kt
+++ b/src/test/java/org/radarbase/output/OffsetRangeFileTest.kt
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
-import org.radarbase.output.accounting.OffsetRange
+import org.radarbase.output.accounting.TopicPartitionOffsetRange
 import org.radarbase.output.accounting.OffsetFilePersistence
 import org.radarbase.output.accounting.OffsetPersistenceFactory
 import org.radarbase.output.accounting.TopicPartition
@@ -30,11 +30,13 @@ import org.radarbase.output.storage.StorageDriver
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Instant
 
 class OffsetRangeFileTest {
     private lateinit var testFile: Path
     private lateinit var storage: StorageDriver
     private lateinit var offsetPersistence: OffsetPersistenceFactory
+    private val lastModified = Instant.now()
 
     @BeforeEach
     @Throws(IOException::class)
@@ -60,29 +62,29 @@ class OffsetRangeFileTest {
     @Throws(IOException::class)
     fun write() {
         offsetPersistence.writer(testFile).use { rangeFile ->
-            rangeFile.add(OffsetRange.parseFilename("a+0+0+1"))
-            rangeFile.add(OffsetRange.parseFilename("a+0+1+2"))
+            rangeFile.add(TopicPartitionOffsetRange.parseFilename("a+0+0+1", lastModified))
+            rangeFile.add(TopicPartitionOffsetRange.parseFilename("a+0+1+2", lastModified))
         }
 
         val set = offsetPersistence.read(testFile)
         assertNotNull(set)
         requireNotNull(set)
-        assertTrue(set.contains(OffsetRange.parseFilename("a+0+0+1")))
-        assertTrue(set.contains(OffsetRange.parseFilename("a+0+1+2")))
-        assertTrue(set.contains(OffsetRange.parseFilename("a+0+0+2")))
-        assertFalse(set.contains(OffsetRange.parseFilename("a+0+0+3")))
-        assertFalse(set.contains(OffsetRange.parseFilename("a+0+2+3")))
-        assertFalse(set.contains(OffsetRange.parseFilename("a+1+0+1")))
-        assertFalse(set.contains(OffsetRange.parseFilename("b+0+0+1")))
+        assertTrue(set.contains(TopicPartitionOffsetRange.parseFilename("a+0+0+1", lastModified)))
+        assertTrue(set.contains(TopicPartitionOffsetRange.parseFilename("a+0+1+2", lastModified)))
+        assertTrue(set.contains(TopicPartitionOffsetRange.parseFilename("a+0+0+2", lastModified)))
+        assertFalse(set.contains(TopicPartitionOffsetRange.parseFilename("a+0+0+3", lastModified)))
+        assertFalse(set.contains(TopicPartitionOffsetRange.parseFilename("a+0+2+3", lastModified)))
+        assertFalse(set.contains(TopicPartitionOffsetRange.parseFilename("a+1+0+1", lastModified)))
+        assertFalse(set.contains(TopicPartitionOffsetRange.parseFilename("b+0+0+1", lastModified)))
     }
 
     @Test
     @Throws(IOException::class)
     fun cleanUp() {
         offsetPersistence.writer(testFile).use { rangeFile ->
-            rangeFile.add(OffsetRange.parseFilename("a+0+0+1"))
-            rangeFile.add(OffsetRange.parseFilename("a+0+1+2"))
-            rangeFile.add(OffsetRange.parseFilename("a+0+4+4"))
+            rangeFile.add(TopicPartitionOffsetRange.parseFilename("a+0+0+1", lastModified))
+            rangeFile.add(TopicPartitionOffsetRange.parseFilename("a+0+1+2", lastModified))
+            rangeFile.add(TopicPartitionOffsetRange.parseFilename("a+0+4+4", lastModified))
         }
 
         storage.newBufferedReader(testFile).use { br ->

--- a/src/test/java/org/radarbase/output/OffsetRangeSetTest.kt
+++ b/src/test/java/org/radarbase/output/OffsetRangeSetTest.kt
@@ -5,20 +5,23 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 
 import org.junit.jupiter.api.Test
-import org.radarbase.output.accounting.OffsetRange
+import org.radarbase.output.accounting.TopicPartitionOffsetRange
 import org.radarbase.output.accounting.OffsetRangeSet
 import org.radarbase.output.accounting.TopicPartition
+import java.time.Instant
 
 class OffsetRangeSetTest {
+    private val lastModified = Instant.now()
+    private val topicPartition = TopicPartition("", 0)
+
     @Test
     fun containsGap() {
-        val topicPartition = TopicPartition("", 0)
-        val am = OffsetRange(topicPartition, -1, 0)
-        val az = OffsetRange(topicPartition, 0, 0)
-        val a = OffsetRange(topicPartition, 0, 1)
-        val c = OffsetRange(topicPartition, 3, 4)
-        val ac = OffsetRange(topicPartition, 0, 3)
-        val ap = OffsetRange(topicPartition, 0, 5)
+        val am = TopicPartitionOffsetRange(topicPartition, OffsetRangeSet.Range(-1, 0, lastModified))
+        val az = TopicPartitionOffsetRange(topicPartition, OffsetRangeSet.Range(0, 0, lastModified))
+        val a = TopicPartitionOffsetRange(topicPartition, OffsetRangeSet.Range(0, 1, lastModified))
+        val c = TopicPartitionOffsetRange(topicPartition, OffsetRangeSet.Range(3, 4, lastModified))
+        val ac = TopicPartitionOffsetRange(topicPartition, OffsetRangeSet.Range(0, 3, lastModified))
+        val ap = TopicPartitionOffsetRange(topicPartition, OffsetRangeSet.Range(0, 5, lastModified))
         val set = OffsetRangeSet()
         assertFalse(set.contains(a))
         assertEquals(0, set.size(topicPartition))
@@ -44,21 +47,5 @@ class OffsetRangeSetTest {
         assertFalse(set.contains(ap))
         set.add(ap)
         assertEquals(1, set.size(topicPartition))
-    }
-
-    @Test
-    fun testGap() {
-        OffsetRangeSet.OffsetRangeLists().run {
-            add(0, 2)
-            add(4, 5)
-            assertEquals(2, size())
-            assertTrue(contains(0, 1))
-            assertFalse(contains(3))
-            assertFalse(contains(0, 5))
-            add(3)
-            assertEquals(1, size())
-            assertTrue(contains(3))
-            assertTrue(contains(0, 5))
-        }
     }
 }

--- a/src/test/java/org/radarbase/output/accounting/OffsetIntervalsTest.kt
+++ b/src/test/java/org/radarbase/output/accounting/OffsetIntervalsTest.kt
@@ -1,0 +1,69 @@
+package org.radarbase.output.accounting
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+internal class OffsetIntervalsTest {
+    private val lastModified = Instant.now()
+    private val futureModified = Instant.now().plusMillis(1)
+
+    @Test
+    fun testGapFuture() {
+        OffsetIntervals().run {
+            add(OffsetRangeSet.Range(0, 2, lastModified))
+            add(OffsetRangeSet.Range(4, 5, lastModified))
+            assertEquals(2, size())
+            assertTrue(contains(OffsetRangeSet.Range(0, 1, lastModified)))
+            assertFalse(contains(OffsetRangeSet.Range(0, 1, futureModified)))
+            assertFalse(contains(3, lastModified))
+            assertFalse(contains(OffsetRangeSet.Range(0, 5, lastModified)))
+            assertFalse(contains(OffsetRangeSet.Range(0, 5, futureModified)))
+            add(3, lastModified)
+            assertEquals(1, size())
+            assertTrue(contains(3, lastModified))
+            assertFalse(contains(3, futureModified))
+            assertTrue(contains(OffsetRangeSet.Range(0, 5, lastModified)))
+            assertFalse(contains(OffsetRangeSet.Range(0, 5, futureModified)))
+        }
+    }
+
+    @Test
+    fun testGapFutureInsert() {
+        OffsetIntervals().run {
+            add(OffsetRangeSet.Range(0, 2, lastModified))
+            add(OffsetRangeSet.Range(4, 5, futureModified))
+            assertEquals(2, size())
+            assertTrue(contains(OffsetRangeSet.Range(0, 1, lastModified)))
+            assertFalse(contains(OffsetRangeSet.Range(0, 1, futureModified)))
+            assertFalse(contains(3, lastModified))
+            assertFalse(contains(OffsetRangeSet.Range(0, 5, lastModified)))
+            assertFalse(contains(OffsetRangeSet.Range(0, 5, futureModified)))
+            assertTrue(contains(OffsetRangeSet.Range(4, 5, lastModified)))
+            assertTrue(contains(OffsetRangeSet.Range(4, 5, futureModified)))
+            add(3, lastModified)
+            assertEquals(1, size())
+            assertTrue(contains(3, lastModified))
+            assertTrue(contains(3, futureModified))
+            assertTrue(contains(OffsetRangeSet.Range(0, 5, lastModified)))
+            assertTrue(contains(OffsetRangeSet.Range(0, 5, futureModified)))
+        }
+    }
+
+    @Test
+    fun testGapFutureAdd() {
+        OffsetIntervals().run {
+            add(OffsetRangeSet.Range(0, 2, lastModified))
+            assertEquals(1, size())
+            assertTrue(contains(OffsetRangeSet.Range(0, 1, lastModified)))
+            assertFalse(contains(OffsetRangeSet.Range(0, 1, futureModified)))
+            assertFalse(contains(3, lastModified))
+            add(3, futureModified)
+            assertEquals(1, size())
+            assertTrue(contains(3, lastModified))
+            assertTrue(contains(3, futureModified))
+            assertTrue(contains(2, lastModified))
+            assertTrue(contains(2, futureModified))
+        }
+    }
+}


### PR DESCRIPTION
~Depends on #59.~

This solves an issue where the HDFS/S3 connector will resume from the first available offset if the last offset in HDFS is later than the one in Kafka. This situation can happen on a fast reboot where Kafka did make available the latest data but it is having problems electing the right leader when the server goes up again, thus losing the latest offsets.