### PR TITLE
Data integrity check

### DIFF
--- a/src/main/java/org/radarbase/output/accounting/Accountant.kt
+++ b/src/main/java/org/radarbase/output/accounting/Accountant.kt
@@ -59,6 +59,11 @@ constructor(factory: FileStoreFactory, topic: String) : Flushable, Closeable {
         } else null
     }
 
+    open fun remove(range: TopicPartitionOffsetRange) = time("accounting.remove") {
+        offsetFile.offsets.remove(range)
+        offsetFile.triggerWrite()
+    }
+
     open fun process(ledger: Ledger) = time("accounting.process") {
         offsetFile.addAll(ledger.offsets)
         offsetFile.triggerWrite()

--- a/src/main/java/org/radarbase/output/accounting/OffsetIntervals.kt
+++ b/src/main/java/org/radarbase/output/accounting/OffsetIntervals.kt
@@ -139,7 +139,7 @@ class OffsetIntervals {
     }
 
     fun remove(range: OffsetRangeSet.Range) {
-        val (from, to, lastModified) = range
+        val (from, to, _) = range
 
         var index = offsetsFrom.binarySearch(from)
 

--- a/src/main/java/org/radarbase/output/accounting/OffsetIntervals.kt
+++ b/src/main/java/org/radarbase/output/accounting/OffsetIntervals.kt
@@ -1,6 +1,7 @@
 package org.radarbase.output.accounting
 
 import com.almworks.integers.LongArray
+import org.apache.jute.Index
 import java.time.Instant
 
 class OffsetIntervals {
@@ -58,19 +59,11 @@ class OffsetIntervals {
             if (index < offsetsFrom.size() && offset == offsetsFrom[index] - 1) {
                 offsetsTo[index - 1] = offsetsTo[index]
                 lastProcessed[index - 1] = max(lastProcessed[index - 1], lastProcessed[index])
-                offsetsFrom.removeAt(index)
-                offsetsTo.removeAt(index)
-                lastProcessed.removeAt(index)
+                removeAt(index)
             }
         } else if (index >= offsetsFrom.size() || offset < offsetsFrom[index] - 1) {
             // cannot concat, enter new range
-            offsetsFrom.insert(index, offset)
-            offsetsTo.insert(index, offset)
-            if (index >= offsetsFrom.size()) {
-                lastProcessed.add(lastModified)
-            } else {
-                lastProcessed.add(index, lastModified)
-            }
+            insert(index, offset, offset, lastModified)
         } else {
             // concat with the stream after it
             offsetsFrom[index] = offset
@@ -91,13 +84,7 @@ class OffsetIntervals {
                 lastProcessed[index] = max(lastProcessed[index], lastModified)
             } else if (index >= offsetsFrom.size() || to < offsetsFrom[index] - 1) {
                 // cannot concat, enter new range
-                offsetsFrom.insert(index, from)
-                offsetsTo.insert(index, to)
-                if (index >= offsetsFrom.size()) {
-                    lastProcessed.add(lastModified)
-                } else {
-                    lastProcessed.add(index, lastModified)
-                }
+                insert(index, from, to, lastModified)
                 return
             } else {
                 // concat with the stream after it
@@ -128,9 +115,7 @@ class OffsetIntervals {
             overlapIndex++
         }
         if (overlapIndex != startIndex) {
-            offsetsFrom.removeRange(startIndex, overlapIndex)
-            offsetsTo.removeRange(startIndex, overlapIndex)
-            lastProcessed.subList(startIndex, overlapIndex).clear()
+            removeRange(startIndex, overlapIndex)
             lastProcessed[index] = maxProcessed
         }
     }
@@ -151,6 +136,64 @@ class OffsetIntervals {
         return ("[" + lastProcessed.indices.joinToString(", ") { i ->
             "(${offsetsFrom[i]} - ${offsetsTo[i]}, ${lastProcessed[i]})"
         } + "]")
+    }
+
+    fun remove(range: OffsetRangeSet.Range) {
+        val (from, to, lastModified) = range
+
+        var index = offsetsFrom.binarySearch(from)
+
+        if (index < 0) {  // search comes between -index - 2 and -index - 1
+            index = -index - 1 // is the next stored offsetFrom index after from
+            // There is a previous from index. Check for overlap
+            if (index > 0) {
+                val prevIndex = index - 1
+                if (from <= offsetsTo[prevIndex]) {  // there is overlap
+                    if (to < offsetsTo[prevIndex]) { // the range falls inside an existing interval
+                        // create new interval after the removed range. The interval before the
+                        // range remains.
+                        insert(index, to + 1, offsetsTo[prevIndex], lastProcessed[prevIndex])
+                    }
+
+                    offsetsTo[prevIndex] = from - 1
+                }
+            }
+        }
+
+        // remove intervals inside range
+        while (offsetsFrom[index] >= from && offsetsTo[index] <= to) {
+            removeAt(index)
+            if (index == offsetsTo.size()) {  // last interval has been removed
+                return
+            }
+        }
+
+        // last interval not completely overlapping with range
+        if (offsetsFrom[index] <= to) {
+            offsetsFrom[index] = to + 1
+        }
+    }
+
+    private fun insert(index: Int, from: Long, to: Long, lastModified: Instant) {
+        offsetsFrom.insert(index, from)
+        offsetsTo.insert(index, to)
+        if (index >= lastProcessed.size) {
+            lastProcessed.add(lastModified)
+        } else {
+            lastProcessed.add(index, lastModified)
+        }
+    }
+
+    private fun removeAt(index: Int) {
+        offsetsTo.removeAt(index)
+        offsetsFrom.removeAt(index)
+        lastProcessed.removeAt(index)
+    }
+
+    private fun removeRange(from: Int, to: Int) {
+        offsetsFrom.removeRange(from, to)
+        offsetsTo.removeRange(from, to)
+        lastProcessed.subList(from, to).clear()
     }
 
     companion object {

--- a/src/main/java/org/radarbase/output/config/CommandLineArgs.kt
+++ b/src/main/java/org/radarbase/output/config/CommandLineArgs.kt
@@ -27,6 +27,12 @@ class CommandLineArgs {
     @Parameter(names = ["-F", "--config-file"], description = "Config file. By default, $RESTRUCTURE_CONFIG_FILE_NAME is tried.")
     var configFile: String? = null
 
+    @Parameter(names = ["-C", "--clean"], description = "Run with old file cleaning enabled.")
+    var clean: Boolean? = null
+
+    @Parameter(names = ["--no-restructure"], description = "Disable restructuring. Only useful if --clean is selected.")
+    var noRestructure: Boolean? = null
+
     @Parameter(names = ["-f", "--format"], description = "Format to use when converting the files. JSON and CSV are available by default.")
     var format: String? = null
 

--- a/src/main/java/org/radarbase/output/config/RestructureConfig.kt
+++ b/src/main/java/org/radarbase/output/config/RestructureConfig.kt
@@ -28,6 +28,8 @@ import java.nio.file.Paths
 data class RestructureConfig(
         /** Whether and how to run as a service. */
         val service: ServiceConfig = ServiceConfig(enable = false),
+        /** Cleaner of old files. */
+        val cleaner: CleanerConfig = CleanerConfig(),
         /** Work limits. */
         val worker: WorkerConfig = WorkerConfig(),
         /** Topic exceptional handling. */
@@ -48,6 +50,9 @@ data class RestructureConfig(
     fun validate() {
         source.validate()
         target.validate()
+        cleaner.validate()
+        service.validate()
+        check(worker.enable || cleaner.enable) { "Either restructuring or cleaning needs to be enabled."}
     }
 
     /** Override configuration using command line arguments. */
@@ -64,6 +69,8 @@ data class RestructureConfig(
         args.format?.let { copy(format = format.copy(type = it)) }
         args.deduplicate?.let { copy(format = format.copy(deduplication = format.deduplication.copy(enable = it))) }
         args.compression?.let { copy(compression = compression.copy(type = it)) }
+        args.clean?.let { copy(cleaner = cleaner.copy(enable = it)) }
+        args.noRestructure?.let { copy(worker = worker.copy(enable = !it)) }
     }
 
     companion object {
@@ -88,17 +95,38 @@ data class RedisConfig(
         /**
          * Prefix to use for creating a lock of a topic.
          */
-        val lockPrefix: String = "radar-output/lock/")
+        val lockPrefix: String = "radar-output/lock")
 
 data class ServiceConfig(
         /** Whether to enable the service mode of this application. */
         val enable: Boolean,
         /** Polling interval in seconds. */
-        val interval: Long = 3600,
+        val interval: Long = 300L,
         /** Age in days after an avro file can be removed. Ignored if not strictly positive. */
-        val deleteAfterDays: Int = -1)
+        val deleteAfterDays: Int = -1) {
+
+    fun validate() {
+        check(interval > 0) { "Cleaner interval must be strictly positive" }
+    }
+}
+
+data class CleanerConfig(
+        /** Whether to enable the cleaner */
+        val enable: Boolean = false,
+        /** How often to run the cleaner */
+        val interval: Long = 1260L,
+        /** Age in days after an avro file can be removed. Must be strictly positive. */
+        val age: Int = 7) {
+
+    fun validate() {
+        check(age > 0) { "Cleaner file age must be strictly positive" }
+        check(interval > 0) { "Cleaner interval must be strictly positive" }
+    }
+}
 
 data class WorkerConfig(
+        /** Whether to enable restructuring */
+        val enable: Boolean = true,
         /** Number of threads to use for processing files. */
         val numThreads: Int = 1,
         /**
@@ -229,9 +257,7 @@ data class HdfsConfig(
     }
 
     fun validate() {
-        if (nameNodes.isEmpty()) {
-            throw IllegalArgumentException("Cannot use HDFS without any name nodes.")
-        }
+        check(nameNodes.isNotEmpty()) { "Cannot use HDFS without any name nodes." }
     }
 }
 

--- a/src/main/java/org/radarbase/output/format/CsvAvroConverter.kt
+++ b/src/main/java/org/radarbase/output/format/CsvAvroConverter.kt
@@ -18,18 +18,10 @@ package org.radarbase.output.format
 
 import com.opencsv.CSVReader
 import com.opencsv.CSVWriter
-import java.nio.ByteBuffer
-import org.apache.avro.Schema
-import org.apache.avro.Schema.Type.*
-import org.apache.avro.generic.GenericData
-import org.apache.avro.generic.GenericFixed
 import org.apache.avro.generic.GenericRecord
-import org.radarbase.output.compression.Compression
-import java.io.*
-import java.nio.file.Files
-import java.nio.file.Path
-import java.util.*
-import kotlin.collections.HashMap
+import java.io.IOException
+import java.io.Reader
+import java.io.Writer
 
 /**
  * Converts deep hierarchical Avro records into flat CSV format. It uses a simple dot syntax in the
@@ -38,25 +30,23 @@ import kotlin.collections.HashMap
  */
 class CsvAvroConverter(
         private val writer: Writer,
-        record: GenericRecord,
         writeHeader: Boolean,
-        reader: Reader
+        reader: Reader,
+        recordHeader: Array<String>
 ) : RecordConverter {
 
     private val csvWriter = CSVWriter(writer)
-    private var headers: List<String>
-    private val values: MutableList<String>
+    private val converter: CsvAvroDataConverter
 
     init {
-        headers = if (writeHeader) {
-            createHeaders(record)
-                    .also { csvWriter.writeNext(it.toTypedArray(), false) }
+        converter = if (writeHeader) {
+            csvWriter.writeNext(recordHeader, false)
+            CsvAvroDataConverter(recordHeader)
         } else {
-            CSVReader(reader).use { requireNotNull(it.readNext()) { "No header found" } }
-                    .toList()
+            CsvAvroDataConverter(CSVReader(reader).use {
+                requireNotNull(it.readNext()) { "No header found" }
+            })
         }
-
-        values = ArrayList(headers.size)
     }
 
     /**
@@ -67,95 +57,18 @@ class CsvAvroConverter(
      */
     @Throws(IOException::class)
     override fun writeRecord(record: GenericRecord): Boolean {
-        try {
-            val retValues = convertRecordValues(record)
-            if (retValues.size < headers.size) {
-                return false
-            }
-
+        return try {
+            val retValues = converter.convertRecordValues(record)
             csvWriter.writeNext(retValues.toTypedArray(), false)
-            values.clear()
-            return true
+            true
         } catch (ex: IllegalArgumentException) {
-            return false
+            false
         } catch (ex: IndexOutOfBoundsException) {
-            return false
+            false
         }
     }
 
-    override fun convertRecord(record: GenericRecord): Map<String, Any?> {
-        values.clear()
-        val schema = record.schema
-        for (field in schema.fields) {
-            convertAvro(values, record.get(field.pos()), field.schema(), field.name())
-        }
-        val map = LinkedHashMap<String, Any>()
-        for (i in headers.indices) {
-            map[headers[i]] = values[i]
-        }
-        values.clear()
-        return map
-    }
-
-    private fun convertRecordValues(record: GenericRecord): List<String> {
-        values.clear()
-        val schema = record.schema
-        for (field in schema.fields) {
-            convertAvro(values, record.get(field.pos()), field.schema(), field.name())
-        }
-        return values
-    }
-
-    private fun convertAvro(values: MutableList<String>, data: Any?, schema: Schema, prefix: String) {
-        when (schema.type) {
-            RECORD -> {
-                val record = data as GenericRecord
-                val subSchema = record.schema
-                for (field in subSchema.fields) {
-                    val subData = record.get(field.pos())
-                    convertAvro(values, subData, field.schema(), prefix + '.'.toString() + field.name())
-                }
-            }
-            MAP -> {
-                val valueType = schema.valueType
-                for ((key, value) in data as Map<*, *>) {
-                    val name = "$prefix.$key"
-                    convertAvro(values, value, valueType, name)
-                }
-            }
-            ARRAY -> {
-                val itemType = schema.elementType
-                for ((i, orig) in (data as List<*>).withIndex()) {
-                    convertAvro(values, orig, itemType, "$prefix.$i")
-                }
-            }
-            UNION -> {
-                val type = GenericData().resolveUnion(schema, data)
-                convertAvro(values, data, schema.types[type], prefix)
-            }
-            BYTES -> {
-                checkHeader(prefix, values.size)
-                values.add(BASE64_ENCODER.encodeToString((data as ByteBuffer).array()))
-            }
-            FIXED -> {
-                checkHeader(prefix, values.size)
-                values.add(BASE64_ENCODER.encodeToString((data as GenericFixed).bytes()))
-            }
-            STRING, ENUM, INT, LONG, DOUBLE, FLOAT, BOOLEAN -> {
-                checkHeader(prefix, values.size)
-                values.add(data.toString())
-            }
-            NULL -> {
-                checkHeader(prefix, values.size)
-                values.add("")
-            }
-            else -> throw IllegalArgumentException("Cannot parse field type " + schema.type)
-        }
-    }
-
-    private fun checkHeader(prefix: String, size: Int) {
-        require(prefix == headers[size]) { "Header $prefix does not match ${headers[size]}" }
-    }
+    override fun convertRecord(record: GenericRecord): Map<String, Any?> = converter.convertRecord(record)
 
     @Throws(IOException::class)
     override fun close() = writer.close()
@@ -164,140 +77,6 @@ class CsvAvroConverter(
     override fun flush() = writer.flush()
 
     companion object {
-        private val BASE64_ENCODER = Base64.getEncoder().withoutPadding()
-
-        val factory = object : RecordConverterFactory {
-            override val extension: String = ".csv"
-
-            override val formats: Collection<String> = setOf("csv")
-
-            @Throws(IOException::class)
-            override fun deduplicate(fileName: String, source: Path, target: Path, compression: Compression, distinctFields: Set<String>, ignoreFields: Set<String>) {
-                val (header, lines) = Files.newInputStream(source).use {
-                    inFile -> compression.decompress(inFile).use {
-                    zipIn -> InputStreamReader(zipIn).use {
-                    inReader -> BufferedReader(inReader).use {
-                    reader -> CSVReader(reader).use {
-                    csvReader ->
-                        val header = csvReader.readNext() ?: return
-                        val lines = generateSequence { csvReader.readNext() }.toList()
-                        Pair(header, lines)
-                    } } } } }
-
-                val distinct = lines.removeDuplicates(header, distinctFields, ignoreFields)
-
-                Files.newOutputStream(target).use {
-                    fileOut -> BufferedOutputStream(fileOut).use {
-                    bufOut -> compression.compress(fileName, bufOut).use {
-                    zipOut -> OutputStreamWriter(zipOut).use {
-                    writer -> CSVWriter(writer).use { csvWriter ->
-                        csvWriter.writeNext(header, false)
-                        csvWriter.writeAll(distinct, false)
-                    } } } } }
-            }
-
-            @Throws(IOException::class)
-            override fun converterFor(writer: Writer, record: GenericRecord,
-                                      writeHeader: Boolean, reader: Reader): CsvAvroConverter =
-                    CsvAvroConverter(writer, record,
-                            writeHeader, reader)
-
-            override val hasHeader: Boolean = true
-        }
-
-        private fun List<Array<String>>.removeDuplicates(
-                header: Array<String>,
-                usingFields: Set<String>,
-                ignoreFields: Set<String>
-        ): List<Array<String>> {
-            if (usingFields.isNotEmpty()) {
-                val fieldIndexes = usingFields.map { f -> header.indexOf(f) }.toIntArray()
-
-                if (fieldIndexes.none { it == -1 }) {
-                    return distinctByLast { line -> line.mapToArrayWrapper(fieldIndexes) }
-                }
-            }
-
-            if (ignoreFields.isNotEmpty()) {
-                val ignoreIndexes = ignoreFields.map { f -> header.indexOf(f) }
-
-                if (ignoreIndexes.any { it != -1 }) {
-                    val fieldIndexes = (header.indices - ignoreIndexes).toIntArray()
-                    return distinctByLast { line -> line.mapToArrayWrapper(fieldIndexes) }
-                }
-            }
-
-            return distinctByLast { ArrayWrapper(it) }
-        }
-
-        private inline fun <reified T> Array<T>.mapToArrayWrapper(indices: IntArray): ArrayWrapper<T> {
-            return ArrayWrapper(Array(indices.size) { i -> this[indices[i]] })
-        }
-
-        private inline fun <T, V> List<T>.distinctByLast(mapping: (T) -> V): List<T> {
-            val map: MutableMap<V, Int> = HashMap()
-            forEachIndexed { i, v ->
-                map[mapping(v)] = i
-            }
-            return map.values.toIntArray()
-                    .apply { sort() }
-                    .map { i -> this[i] }
-        }
-
-        internal fun createHeaders(record: GenericRecord): List<String> {
-            val headers = ArrayList<String>()
-            val schema = record.schema
-            for (field in schema.fields) {
-                createHeader(headers, record.get(field.pos()), field.schema(), field.name())
-            }
-            return headers
-        }
-
-        private fun createHeader(headers: MutableList<String>, data: Any?, schema: Schema, prefix: String) {
-            when (schema.type) {
-                RECORD -> {
-                    val record = data as GenericRecord
-                    val subSchema = record.schema
-                    for (field in subSchema.fields) {
-                        val subData = record.get(field.pos())
-                        createHeader(headers, subData, field.schema(), prefix + '.'.toString() + field.name())
-                    }
-                }
-                MAP -> {
-                    val valueType = schema.valueType
-                    for ((key, value) in data as Map<*, *>) {
-                        val name = "$prefix.$key"
-                        createHeader(headers, value, valueType, name)
-                    }
-                }
-                ARRAY -> {
-                    val itemType = schema.elementType
-                    for ((i, orig) in (data as List<*>).withIndex()) {
-                        createHeader(headers, orig, itemType, "$prefix.$i")
-                    }
-                }
-                UNION -> {
-                    val type = GenericData().resolveUnion(schema, data)
-                    createHeader(headers, data, schema.types[type], prefix)
-                }
-                BYTES, FIXED, ENUM, STRING, INT, LONG, DOUBLE, FLOAT, BOOLEAN, NULL -> headers.add(prefix)
-                else -> throw IllegalArgumentException("Cannot parse field type " + schema.type)
-            }
-        }
-    }
-
-    private class ArrayWrapper<T>(val values: Array<T>) {
-        private val hashCode = values.contentHashCode()
-
-        override fun equals(other: Any?): Boolean {
-            if (this === other) return true
-            if (javaClass != other?.javaClass) return false
-
-            other as ArrayWrapper<*>
-
-            return values.contentEquals(other.values)
-        }
-
-        override fun hashCode(): Int = hashCode
+        val factory = CsvAvroConverterFactory()
     }
 }

--- a/src/main/java/org/radarbase/output/format/CsvAvroConverterFactory.kt
+++ b/src/main/java/org/radarbase/output/format/CsvAvroConverterFactory.kt
@@ -1,0 +1,182 @@
+package org.radarbase.output.format
+
+import com.opencsv.CSVReader
+import com.opencsv.CSVWriter
+import org.apache.avro.generic.GenericRecord
+import org.radarbase.output.compression.Compression
+import org.radarbase.output.util.TimeUtil.parseDate
+import org.radarbase.output.util.TimeUtil.parseDateTime
+import org.radarbase.output.util.TimeUtil.parseTime
+import org.radarbase.output.util.TimeUtil.toDouble
+import java.io.*
+import java.nio.file.Files
+import java.nio.file.Path
+
+class CsvAvroConverterFactory: RecordConverterFactory {
+    override val extension: String = ".csv"
+
+    override val formats: Collection<String> = setOf("csv")
+
+    @Throws(IOException::class)
+    override fun deduplicate(fileName: String, source: Path, target: Path, compression: Compression, distinctFields: Set<String>, ignoreFields: Set<String>) {
+        val (header, lines) = Files.newInputStream(source).use {
+            processLines(it, compression) { header, lines ->
+                Pair(header, lines.toList())
+            }
+        }
+
+        if (header == null) return
+
+        val indexes = fieldIndexes(header, distinctFields, ignoreFields)
+        val distinct = lines.distinctByLast { line -> ArrayWrapper(line.byIndex(indexes)) }
+
+        Files.newOutputStream(target).use { fileOut ->
+            BufferedOutputStream(fileOut).use { bufOut ->
+                compression.compress(fileName, bufOut).use { zipOut ->
+                    OutputStreamWriter(zipOut).use { writer ->
+                        CSVWriter(writer).use { csvWriter ->
+                            csvWriter.writeNext(header, false)
+                            csvWriter.writeAll(distinct, false)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private val fieldTimeParsers = listOf(
+            Pair<String, (String) -> Double?>("value.time", { it.parseTime() }),
+            Pair<String, (String) -> Double?>("key.timeStart", { it.parseTime() }),
+            Pair<String, (String) -> Double?>("key.start", { it.parseTime() }),
+            Pair<String, (String) -> Double?>("value.dateTime", { it.parseDateTime()?.toDouble() }),
+            Pair<String, (String) -> Double?>("value.date", { it.parseDate()?.toDouble() }),
+            Pair<String, (String) -> Double?>("value.timeReceived", { it.parseTime() }),
+            Pair<String, (String) -> Double?>("value.timeReceived", { it.parseTime() }),
+            Pair<String, (String) -> Double?>("value.timeCompleted", { it.parseTime() })
+    )
+
+    override fun readTimeSeconds(source: InputStream, compression: Compression): Pair<Array<String>, List<Double>>? {
+        return processLines(source, compression) { header, lines ->
+            header ?: return@processLines null
+
+            val parsers = fieldTimeParsers.mapNotNull { (key, parser) ->
+                header.indexOf(key)
+                        .takeIf { it >= 0 }
+                        ?.let { Pair(it, parser) }
+            }
+
+            return Pair(header, if (parsers.isEmpty()) emptyList() else {
+                lines.mapNotNull { line ->
+                    for ((index, parser) in parsers) {
+                        parser(line[index])?.let {
+                            return@mapNotNull it
+                        }
+                    }
+                    null
+                }.toList()
+            })
+        }
+    }
+
+    override fun contains(
+            source: Path,
+            record: GenericRecord,
+            compression: Compression,
+            usingFields: Set<String>,
+            ignoreFields: Set<String>
+    ): Boolean = Files.newInputStream(source).use { input ->
+        processLines(input, compression) { header, lines ->
+            checkNotNull(header) { "Empty file found" }
+            val converter = CsvAvroDataConverter(header)
+            val recordValues = converter.convertRecordValues(record).toTypedArray()
+            val indexes = fieldIndexes(header, usingFields, ignoreFields)
+
+            if (indexes == null) {
+                lines.any { line -> recordValues.contentEquals(line) }
+            } else {
+                lines.any { line -> indexes.all { i -> recordValues[i] == line[i] } }
+            }
+        }
+    }
+
+    @Throws(IOException::class)
+    override fun converterFor(writer: Writer, record: GenericRecord,
+                              writeHeader: Boolean, reader: Reader): CsvAvroConverter =
+            CsvAvroConverter(writer, writeHeader, reader, headerFor(record))
+
+    override val hasHeader: Boolean = true
+
+    companion object {
+        private inline fun <T> processLines(
+                input: InputStream,
+                compression: Compression,
+                process: (header: Array<String>?, lines: Sequence<Array<String>>) -> T
+        ): T = compression.decompress(input).use { zipIn ->
+            InputStreamReader(zipIn).use { inReader ->
+                BufferedReader(inReader).use { bufReader ->
+                    CSVReader(bufReader).use { csvReader ->
+                        val header = csvReader.readNext()
+                        val lines = if (header == null) emptySequence() else generateSequence { csvReader.readNext() }
+                        process(header, lines)
+                    }
+                }
+            }
+        }
+
+
+        /**
+         * Make a copy of the current list that only contains distinct entries.
+         * For duplicate entries, the last entry in the list is selected. Being distinct is
+         * determined by the provided mapping.
+         * @param <T> type of data.
+         * @param <V> type that is mapped to for distinguishing. This type should have valid
+         *            hashCode and equals implementations.
+         */
+        private inline fun <T, V> List<T>.distinctByLast(mapping: (T) -> V): List<T> {
+            val map: MutableMap<V, Int> = HashMap()
+            forEachIndexed { i, v ->
+                map[mapping(v)] = i
+            }
+            return map.values.toIntArray()
+                    .apply { sort() }
+                    .map { i -> this[i] }
+        }
+
+        private fun fieldIndexes(
+                header: Array<String>,
+                usingFields: Set<String>,
+                ignoreFields: Set<String>
+        ): IntArray? = usingFields
+                .takeIf { it.isNotEmpty() }
+                ?.map { f -> header.indexOf(f) }
+                ?.takeIf { it.none { idx -> idx == -1 } }
+                ?.toIntArray()
+                ?: ignoreFields
+                        .takeIf { it.isNotEmpty() }
+                        ?.map { f -> header.indexOf(f) }
+                        ?.takeIf { it.any { idx -> idx != -1 } }
+                        ?.let { (header.indices - it).toIntArray() }
+
+        private class ArrayWrapper<T>(val values: Array<T>) {
+            private val hashCode = values.contentHashCode()
+
+            override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                if (javaClass != other?.javaClass) return false
+
+                other as ArrayWrapper<*>
+
+                return values.contentEquals(other.values)
+            }
+
+            override fun hashCode(): Int = hashCode
+        }
+
+        @Throws(IndexOutOfBoundsException::class)
+        inline fun <reified T> Array<T>.byIndex(
+                indexes: IntArray?
+        ): Array<T> = if (indexes == null) this else {
+            Array(indexes.size) { i -> this[indexes[i]] }
+        }
+    }
+}

--- a/src/main/java/org/radarbase/output/format/CsvAvroDataConverter.kt
+++ b/src/main/java/org/radarbase/output/format/CsvAvroDataConverter.kt
@@ -1,0 +1,96 @@
+package org.radarbase.output.format
+
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericData
+import org.apache.avro.generic.GenericFixed
+import org.apache.avro.generic.GenericRecord
+import java.nio.ByteBuffer
+import java.util.*
+import kotlin.collections.ArrayList
+
+internal class CsvAvroDataConverter(
+        private val headers: Array<String>
+) {
+    private val values: MutableList<String> = ArrayList(this.headers.size)
+
+    fun convertRecord(record: GenericRecord): Map<String, Any?> {
+        values.clear()
+        val schema = record.schema
+        for (field in schema.fields) {
+            convertAvro(values, record.get(field.pos()), field.schema(), field.name())
+        }
+        val map = LinkedHashMap<String, Any>()
+        for (i in headers.indices) {
+            map[headers[i]] = values[i]
+        }
+        values.clear()
+        return map
+    }
+
+    fun convertRecordValues(record: GenericRecord): List<String> {
+        values.clear()
+        val schema = record.schema
+        for (field in schema.fields) {
+            convertAvro(values, record.get(field.pos()), field.schema(), field.name())
+        }
+        if (values.size < headers.size) {
+            throw IllegalArgumentException("Values and headers do not match")
+        }
+        return values
+    }
+
+    private fun convertAvro(values: MutableList<String>, data: Any?, schema: Schema, prefix: String) {
+        when (schema.type) {
+            Schema.Type.RECORD -> {
+                val record = data as GenericRecord
+                val subSchema = record.schema
+                for (field in subSchema.fields) {
+                    val subData = record.get(field.pos())
+                    convertAvro(values, subData, field.schema(), prefix + '.'.toString() + field.name())
+                }
+            }
+            Schema.Type.MAP -> {
+                val valueType = schema.valueType
+                for ((key, value) in data as Map<*, *>) {
+                    val name = "$prefix.$key"
+                    convertAvro(values, value, valueType, name)
+                }
+            }
+            Schema.Type.ARRAY -> {
+                val itemType = schema.elementType
+                for ((i, orig) in (data as List<*>).withIndex()) {
+                    convertAvro(values, orig, itemType, "$prefix.$i")
+                }
+            }
+            Schema.Type.UNION -> {
+                val type = GenericData().resolveUnion(schema, data)
+                convertAvro(values, data, schema.types[type], prefix)
+            }
+            Schema.Type.BYTES -> {
+                checkHeader(prefix, values.size)
+                values.add(BASE64_ENCODER.encodeToString((data as ByteBuffer).array()))
+            }
+            Schema.Type.FIXED -> {
+                checkHeader(prefix, values.size)
+                values.add(BASE64_ENCODER.encodeToString((data as GenericFixed).bytes()))
+            }
+            Schema.Type.STRING, Schema.Type.ENUM, Schema.Type.INT, Schema.Type.LONG, Schema.Type.DOUBLE, Schema.Type.FLOAT, Schema.Type.BOOLEAN -> {
+                checkHeader(prefix, values.size)
+                values.add(data.toString())
+            }
+            Schema.Type.NULL -> {
+                checkHeader(prefix, values.size)
+                values.add("")
+            }
+            else -> throw IllegalArgumentException("Cannot parse field type " + schema.type)
+        }
+    }
+
+    private fun checkHeader(prefix: String, size: Int) {
+        require(prefix == headers[size]) { "Header $prefix does not match ${headers[size]}" }
+    }
+
+    companion object {
+        private val BASE64_ENCODER = Base64.getEncoder().withoutPadding()
+    }
+}

--- a/src/main/java/org/radarbase/output/format/JsonAvroConverterFactory.kt
+++ b/src/main/java/org/radarbase/output/format/JsonAvroConverterFactory.kt
@@ -1,0 +1,63 @@
+package org.radarbase.output.format
+
+import com.fasterxml.jackson.databind.JsonNode
+import org.apache.avro.generic.GenericRecord
+import org.radarbase.output.compression.Compression
+import org.radarbase.output.format.JsonAvroConverter.Companion.JSON_READER
+import org.radarbase.output.format.JsonAvroConverter.Companion.JSON_WRITER
+import org.radarbase.output.util.TimeUtil.getDate
+import org.radarbase.output.util.TimeUtil.parseDate
+import org.radarbase.output.util.TimeUtil.parseDateTime
+import org.radarbase.output.util.TimeUtil.toDouble
+import java.io.*
+import java.nio.file.Files
+import java.nio.file.Path
+
+class JsonAvroConverterFactory : RecordConverterFactory {
+    override val extension: String = ".json"
+
+    override val formats: Collection<String> = setOf("json")
+
+    private val converter = JsonAvroDataConverter()
+
+    @Throws(IOException::class)
+    override fun converterFor(writer: Writer,
+                              record: GenericRecord,
+                              writeHeader: Boolean,
+                              reader: Reader): RecordConverter = JsonAvroConverter(writer, converter)
+
+    override fun readTimeSeconds(source: InputStream, compression: Compression): Pair<Array<String>?, List<Double>>? {
+        return compression.decompress(source).use {
+            zipIn -> InputStreamReader(zipIn).use {
+            inReader -> BufferedReader(inReader).use {
+            reader ->
+            Pair(null, fileSequence(reader, hasHeader)
+                    .mapNotNull {
+                        val record = JSON_READER.readTree(it)
+                        getDate(record.get("key"), record.get("value"))
+                    }
+                    .toList())
+        } } }
+    }
+
+    override fun contains(source: Path, record: GenericRecord, compression: Compression, usingFields: Set<String>, ignoreFields: Set<String>): Boolean {
+        val recordString = JSON_WRITER.writeValueAsString(converter.convertRecord(record))
+
+        return Files.newInputStream(source).use {
+            inFile -> compression.decompress(inFile).use {
+            zipIn -> InputStreamReader(zipIn).use {
+            inReader -> BufferedReader(inReader).use {
+            reader ->
+            fileSequence(reader, hasHeader)
+                    .any { recordString == it }
+        } } } }
+    }
+
+    companion object {
+        fun fileSequence(reader: BufferedReader, withHeader: Boolean): Sequence<String> {
+            if (withHeader) reader.readLine() // skip header
+
+            return generateSequence { reader.readLine() }
+        }
+    }
+}

--- a/src/main/java/org/radarbase/output/format/JsonAvroDataConverter.kt
+++ b/src/main/java/org/radarbase/output/format/JsonAvroDataConverter.kt
@@ -1,0 +1,52 @@
+package org.radarbase.output.format
+
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericData
+import org.apache.avro.generic.GenericFixed
+import org.apache.avro.generic.GenericRecord
+import java.nio.ByteBuffer
+import java.util.ArrayList
+import java.util.HashMap
+
+class JsonAvroDataConverter {
+    fun convertRecord(record: GenericRecord): Map<String, Any?> {
+        val map = HashMap<String, Any?>()
+        val schema = record.schema
+        for (field in schema.fields) {
+            map[field.name()] = convertAvro(record.get(field.pos()), field.schema())
+        }
+        return map
+    }
+
+    private fun convertAvro(data: Any?, schema: Schema): Any? {
+        when (schema.type) {
+            Schema.Type.RECORD -> return convertRecord(data as GenericRecord)
+            Schema.Type.MAP -> {
+                val value = HashMap<String, Any?>()
+                val valueType = schema.valueType
+                for ((key, value1) in data as Map<*, *>) {
+                    value[key.toString()] = convertAvro(value1, valueType)
+                }
+                return value
+            }
+            Schema.Type.ARRAY -> {
+                val origList = data as List<*>
+                val itemType = schema.elementType
+                val list = ArrayList<Any?>(origList.size)
+                for (orig in origList) {
+                    list.add(convertAvro(orig, itemType))
+                }
+                return list
+            }
+            Schema.Type.UNION -> {
+                val type = GenericData().resolveUnion(schema, data)
+                return convertAvro(data, schema.types[type])
+            }
+            Schema.Type.BYTES -> return (data as ByteBuffer).array()
+            Schema.Type.FIXED -> return (data as GenericFixed).bytes()
+            Schema.Type.ENUM, Schema.Type.STRING -> return data.toString()
+            Schema.Type.INT, Schema.Type.LONG, Schema.Type.DOUBLE, Schema.Type.FLOAT, Schema.Type.BOOLEAN, Schema.Type.NULL -> return data
+            else -> throw IllegalArgumentException("Cannot parse field type " + schema.type)
+        }
+    }
+}

--- a/src/main/java/org/radarbase/output/source/AzureSourceStorage.kt
+++ b/src/main/java/org/radarbase/output/source/AzureSourceStorage.kt
@@ -26,7 +26,9 @@ class AzureSourceStorage(
                 .delete()
     }
 
-    override fun reader(): SourceStorage.SourceStorageReader = AzureSourceStorageReader()
+    override val walker: SourceStorageWalker = GeneralSourceStorageWalker(this)
+
+    override fun createReader(): SourceStorage.SourceStorageReader = AzureSourceStorageReader()
 
     private inner class AzureSourceStorageReader: SourceStorage.SourceStorageReader {
         private val tempDir = TemporaryDirectory(tempPath, "worker-")

--- a/src/main/java/org/radarbase/output/source/GeneralSourceStorageWalker.kt
+++ b/src/main/java/org/radarbase/output/source/GeneralSourceStorageWalker.kt
@@ -1,0 +1,34 @@
+package org.radarbase.output.source
+
+import java.nio.file.Path
+
+class GeneralSourceStorageWalker(
+        private val kafkaStorage: SourceStorage
+): SourceStorageWalker {
+    override fun walkRecords(topic: String, topicPath: Path): Sequence<TopicFile> = kafkaStorage.list(topicPath)
+            .flatMap { status ->
+                val filename = status.path.fileName.toString()
+                when {
+                    status.isDirectory && filename != "+tmp" -> walkRecords(topic, status.path)
+                    filename.endsWith(".avro") -> sequenceOf(TopicFile(topic, status.path, status.lastModified))
+                    else -> emptySequence()
+                }
+            }
+
+    private fun findTopicPaths(path: Path): Sequence<Path> {
+        val fileStatuses = kafkaStorage.list(path)
+        val avroFile = fileStatuses.find {  !it.isDirectory && it.path.fileName.toString().endsWith(".avro", true) }
+
+        return if (avroFile != null) {
+            sequenceOf(avroFile.path.parent.parent)
+        } else {
+            fileStatuses.asSequence()
+                    .filter { it.isDirectory && it.path.fileName.toString() != "+tmp" }
+                    .flatMap { findTopicPaths(it.path) }
+        }
+    }
+
+    override fun walkTopics(root: Path, exclude: Set<String>): Sequence<Path> = findTopicPaths(root)
+            .distinct()
+            .filter { it.fileName.toString() !in exclude }
+}

--- a/src/main/java/org/radarbase/output/source/HdfsSourceStorage.kt
+++ b/src/main/java/org/radarbase/output/source/HdfsSourceStorage.kt
@@ -11,7 +11,9 @@ import java.time.Instant
 class HdfsSourceStorage(
         private val fileSystem: FileSystem
 ): SourceStorage {
-    override fun reader(): SourceStorage.SourceStorageReader = HDFSSourceStorageReader()
+    override val walker: SourceStorageWalker = GeneralSourceStorageWalker(this)
+
+    override fun createReader(): SourceStorage.SourceStorageReader = HDFSSourceStorageReader()
 
     override fun list(path: Path): Sequence<SimpleFileStatus> {
         return fileSystem.listStatus(path.toHdfsPath())

--- a/src/main/java/org/radarbase/output/source/S3SourceStorage.kt
+++ b/src/main/java/org/radarbase/output/source/S3SourceStorage.kt
@@ -14,6 +14,8 @@ class S3SourceStorage(
         private val bucket: String,
         private val tempPath: Path
 ): SourceStorage {
+    override val walker: SourceStorageWalker = GeneralSourceStorageWalker(this)
+
     override fun list(path: Path): Sequence<SimpleFileStatus> = s3Client.listObjects(bucket, path.toString())
             .asSequence()
             .map {
@@ -25,7 +27,7 @@ class S3SourceStorage(
         s3Client.removeObject(bucket, path.toKey())
     }
 
-    override fun reader(): SourceStorage.SourceStorageReader = S3SourceStorageReader()
+    override fun createReader(): SourceStorage.SourceStorageReader = S3SourceStorageReader()
 
     private inner class S3SourceStorageReader: SourceStorage.SourceStorageReader {
         private val tempDir = TemporaryDirectory(tempPath, "worker-")

--- a/src/main/java/org/radarbase/output/source/SourceStorage.kt
+++ b/src/main/java/org/radarbase/output/source/SourceStorage.kt
@@ -7,11 +7,13 @@ import java.nio.file.Path
 /** Source storage type. */
 interface SourceStorage {
     /** Create a reader for the storage medium. It should be closed by the caller. */
-    fun reader(): SourceStorageReader
+    fun createReader(): SourceStorageReader
     /** List all files in the given directory. */
     fun list(path: Path): Sequence<SimpleFileStatus>
     /** Delete given file. Will not delete any directories. */
     fun delete(path: Path)
+    /** Find records and topics. */
+    val walker: SourceStorageWalker
 
     /**
      * File reader for the storage medium.

--- a/src/main/java/org/radarbase/output/source/SourceStorageWalker.kt
+++ b/src/main/java/org/radarbase/output/source/SourceStorageWalker.kt
@@ -1,0 +1,17 @@
+package org.radarbase.output.source
+
+import java.nio.file.Path
+
+interface SourceStorageWalker {
+    /**
+     * Recursively returns all records in a sequence of a given topic with path.
+     * The path must only contain records of a single topic, this is not verified.
+     */
+    fun walkRecords(topic: String, topicPath: Path): Sequence<TopicFile>
+
+    /**
+     * Recursively find all topic root paths of records in the given path.
+     * Exclude paths belonging to the set of given excluded topics.
+     */
+    fun walkTopics(root: Path, exclude: Set<String> = emptySet()): Sequence<Path>
+}

--- a/src/main/java/org/radarbase/output/util/TimeUtil.kt
+++ b/src/main/java/org/radarbase/output/util/TimeUtil.kt
@@ -1,0 +1,146 @@
+package org.radarbase.output.util
+
+import com.fasterxml.jackson.databind.JsonNode
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericRecord
+import java.math.RoundingMode
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeParseException
+
+object TimeUtil {
+    private val NANO_MULTIPLIER = 1_000_000_000.toBigDecimal()
+
+    /**
+     * Get the date contained in given records
+     * @param key key field of the record
+     * @param value value field of the record
+     * @return date contained in the values of either record, or `null` if not found or
+     * it cannot be parsed.
+     */
+    fun getDate(key: GenericRecord?,
+                value: GenericRecord?): Instant? {
+        value?.timeOrNull("time")
+                ?.let { return it }
+
+        key?.run {
+            timeOrNull("timeStart")
+                    ?.let { return it }
+
+
+            schema.getField("start")
+                    ?.takeIf { it.schema().type == Schema.Type.LONG }
+                    ?.let { return ((get(it.pos()) as Long) / 1000.0).toInstant() }
+        }
+
+        value?.run {
+            dateTimeOrNull("dateTime")
+                    ?.let { return it }
+
+            dateOrNull("date")
+                    ?.let { return it }
+
+            timeOrNull("timeReceived")
+                    ?.let { return it }
+            timeOrNull("timeCompleted")
+                    ?.let { return it }
+        }
+
+        return null
+    }
+
+    fun getDate(key: JsonNode?, value: JsonNode?): Double? {
+        value?.get("time")
+                ?.takeIf { it.isNumber }
+                ?.let { return it.asDouble() }
+
+        key?.run {
+            get("timeStart")
+                    ?.takeIf { it.isNumber }
+                    ?.let { return it.asDouble() }
+
+            get("start")
+                    ?.takeIf { it.isNumber }
+                    ?.let { return it.asLong() / 1000.0 }
+        }
+
+        value?.run {
+            get("dateTime")
+                    ?.takeIf { it.isTextual }
+                    ?.let { node -> return node.asText().parseDateTime()?.toDouble() }
+
+            get("date")
+                    ?.takeIf { it.isTextual }
+                    ?.let { node -> return node.asText().parseDate()?.toDouble() }
+
+            get("timeReceived")
+                    ?.takeIf { it.isNumber }
+                    ?.let { return it.asDouble() }
+
+            get("timeCompleted")
+                    ?.takeIf { it.isNumber }
+                    ?.let { return it.asDouble() }
+        }
+
+        return null
+    }
+
+    private fun GenericRecord.timeOrNull(fieldName: String): Instant? = schema.getField(fieldName)
+            ?.takeIf { it.schema().type == Schema.Type.DOUBLE }
+            ?.let { (get(it.pos()) as Double).toInstant() }
+
+    /**
+     * Parse the dateTime field of a record, if present.
+     *
+     * @param fieldName field that contains the date time
+     * @return `Instant` representing the dateTime or `null` if the field cannot be
+     * found or parsed.
+     */
+    private fun GenericRecord.dateTimeOrNull(fieldName: String): Instant? = schema.getField(fieldName)
+            ?.takeIf { it.schema().type == Schema.Type.STRING }
+            ?.let { get(it.pos()).toString().parseDateTime() }
+
+    /**
+     * Parse the date field of a record, if present.
+     *
+     * @param fieldName field that contains the date
+     * @return `Instant` representing the start of given date or `null` if the field
+     * cannot be found or parsed.
+     */
+    private fun GenericRecord.dateOrNull(fieldName: String): Instant? = schema.getField(fieldName)
+            ?.takeIf { it.schema().type == Schema.Type.STRING }
+            ?.let { get(it.pos()).toString().parseDate() }
+
+    private fun Double.toInstant(): Instant {
+        val time = toBigDecimal()
+        val seconds = time.toLong()
+        val nanoseconds = ((time - seconds.toBigDecimal()) * NANO_MULTIPLIER).toLong()
+        return Instant.ofEpochSecond(seconds, nanoseconds)
+    }
+
+    fun String.parseTime(): Double? = toDoubleOrNull()
+
+    fun String.parseDate(): Instant? = try {
+        LocalDate.parse(this)
+                .atStartOfDay(ZoneOffset.UTC)
+                .toInstant()
+    } catch (ex: DateTimeParseException) {
+        null
+    }
+
+    fun String.parseDateTime(): Instant? = try {
+        if (this[lastIndex] == 'Z') {
+            Instant.parse(this)
+        } else {
+            LocalDateTime.parse(this).toInstant(ZoneOffset.UTC)
+        }
+    } catch (ex: DateTimeParseException) {
+        null
+    }
+
+    fun Instant.toDouble() = (epochSecond.toBigDecimal()
+            + (nano.toBigDecimal().divide(NANO_MULTIPLIER, 9, RoundingMode.HALF_UP))
+            ).toDouble()
+}

--- a/src/main/java/org/radarbase/output/util/Timer.kt
+++ b/src/main/java/org/radarbase/output/util/Timer.kt
@@ -24,9 +24,9 @@ import org.radarbase.output.util.ProgressBar.Companion.appendTime
 import java.util.*
 
 /** Timer for multi-threaded timings. The timer may be disabled to increase program performance.  */
-internal object Timer {
+object Timer {
     private val shutdownHook = Thread({ println(Timer) }, "Timer")
-    private val times: ConcurrentMap<String, MutableTimerEntry> = ConcurrentHashMap()
+    val times: ConcurrentMap<String, MutableTimerEntry> = ConcurrentHashMap()
 
     /**
      * All currently measured timings.
@@ -102,7 +102,7 @@ internal object Timer {
         return builder.toString()
     }
 
-    internal class MutableTimerEntry {
+    class MutableTimerEntry {
         private val invocations = LongAdder()
         private val totalTime = LongAdder()
         private val threads = ConcurrentHashMap<Long, Long>()

--- a/src/main/java/org/radarbase/output/util/Timer.kt
+++ b/src/main/java/org/radarbase/output/util/Timer.kt
@@ -24,7 +24,7 @@ import org.radarbase.output.util.ProgressBar.Companion.appendTime
 import java.util.*
 
 /** Timer for multi-threaded timings. The timer may be disabled to increase program performance.  */
-object Timer {
+internal object Timer {
     private val shutdownHook = Thread({ println(Timer) }, "Timer")
     private val times: ConcurrentMap<String, MutableTimerEntry> = ConcurrentHashMap()
 
@@ -39,7 +39,7 @@ object Timer {
      * Whether the timer is enabled. A disabled timer will have much less performance impact on
      * timed code.
      */
-    @get:Synchronized
+    @Volatile
     @set:Synchronized
     var isEnabled: Boolean = false
         set(value) {
@@ -57,7 +57,7 @@ object Timer {
     /**
      * Time a given action, labeled by an action type.
      */
-    fun <T> time(type: String, action: () -> T): T {
+    inline fun <T> time(type: String, action: () -> T): T {
         return if (isEnabled) {
             val startTime = System.nanoTime()
             try {
@@ -102,10 +102,10 @@ object Timer {
         return builder.toString()
     }
 
-    private class MutableTimerEntry {
-        val invocations = LongAdder()
-        val totalTime = LongAdder()
-        val threads = ConcurrentHashMap<Long, Long>()
+    internal class MutableTimerEntry {
+        private val invocations = LongAdder()
+        private val totalTime = LongAdder()
+        private val threads = ConcurrentHashMap<Long, Long>()
 
         fun add(nanoTime: Long) {
             invocations.increment()

--- a/src/main/java/org/radarbase/output/worker/ContainsFileCache.kt
+++ b/src/main/java/org/radarbase/output/worker/ContainsFileCache.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 The Hyve
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.radarbase.output.worker
+
+import org.apache.avro.generic.GenericRecord
+import org.radarbase.output.FileStoreFactory
+import org.radarbase.output.format.RecordConverterFactory
+import org.radarbase.output.util.TimeUtil.getDate
+import org.radarbase.output.util.TimeUtil.toDouble
+import java.io.FileNotFoundException
+import java.nio.file.Path
+
+/** Keeps path handles of a path.  */
+class ContainsFileCache(
+        factory: FileStoreFactory,
+        /** File that the cache is maintaining.  */
+        val path: Path
+) : Comparable<ContainsFileCache> {
+    private val converterFactory: RecordConverterFactory = factory.recordConverter
+    private var lastUse: Long = 0
+    private val header: Array<String>?
+    private val times: Set<Double>
+
+    init {
+        val targetStorage = factory.targetStorage
+        targetStorage.status(path)
+                ?.takeIf { it.size > 0 }
+                ?: throw FileNotFoundException()
+
+        val readDates = targetStorage.newInputStream(path).use {
+            converterFactory.readTimeSeconds(it, factory.compression)
+        } ?: throw FileNotFoundException()
+
+        header = readDates.first
+        times = readDates.second.toSet()
+    }
+
+    fun contains(record: GenericRecord): Boolean {
+        if (header != null) {
+            val recordHeader = converterFactory.headerFor(record)
+            if (!recordHeader.contentEquals(header)) {
+                throw IllegalArgumentException("Header mismatch")
+            }
+        }
+
+        val recordDate = getDate(
+                record.get("key") as? GenericRecord,
+                record.get("value") as? GenericRecord)?.toDouble()
+
+        return recordDate == null || recordDate in times
+    }
+
+    /**
+     * Compares time that the filecaches were last used. If equal, it lexicographically compares
+     * the absolute path of the path.
+     * @param other FileCache to compare with.
+     */
+    override fun compareTo(other: ContainsFileCache): Int = comparator.compare(this, other)
+
+    companion object {
+        val comparator = compareBy(ContainsFileCache::lastUse, ContainsFileCache::path)
+    }
+}

--- a/src/main/java/org/radarbase/output/worker/ContainsFileCacheStore.kt
+++ b/src/main/java/org/radarbase/output/worker/ContainsFileCacheStore.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017 The Hyve
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.radarbase.output.worker
+
+import org.apache.avro.generic.GenericRecord
+import org.radarbase.output.FileStoreFactory
+import org.radarbase.output.util.Timer.time
+import java.io.Closeable
+import java.io.FileNotFoundException
+import java.io.IOException
+import java.nio.file.Path
+import java.util.*
+
+/**
+ * Caches open file handles. If more than the limit is cached, the half of the files that were used
+ * the longest ago cache are evicted from cache.
+ */
+class ContainsFileCacheStore(private val factory: FileStoreFactory) : Closeable {
+    private val caches: MutableMap<Path, ContainsFileCache>
+    private val maxCacheSize: Int
+    private val schemasAdded: MutableMap<Path, Path>
+
+    init {
+        val config = factory.config
+        this.maxCacheSize = config.worker.cacheSize
+        this.caches = HashMap(maxCacheSize * 4 / 3 + 1)
+        this.schemasAdded = HashMap()
+    }
+
+    /**
+     * Append a record to given file. If the file handle and writer are already open in this cache,
+     * those will be used. Otherwise, the file will be opened and the file handle cached.
+     *
+     * @param path file to append data to
+     * @param record data
+     * @return Integer value according to one of the response codes.
+     * @throws IOException when failing to open a file or writing to it.
+     */
+    @Throws(IOException::class)
+    fun contains(path: Path, record: GenericRecord): FindResult {
+        return try {
+            val fileCache = caches[path]
+                    ?: time("cleaner.cache") {
+                        ensureCapacity()
+                        ContainsFileCache(factory, path)
+                                .also { caches[path] = it }
+                    }
+
+            time("cleaner.contains") {
+                if (fileCache.contains(record)) FindResult.FOUND else FindResult.NOT_FOUND
+            }
+        } catch (ex: FileNotFoundException) {
+            FindResult.FILE_NOT_FOUND
+        } catch (ex: IllegalArgumentException) {
+            FindResult.BAD_SCHEMA
+        } catch (ex: IndexOutOfBoundsException) {
+            FindResult.BAD_SCHEMA
+        }
+    }
+
+    /**
+     * Ensure that a new filecache can be added. Evict files used longest ago from cache if needed.
+     */
+    @Throws(IOException::class)
+    private fun ensureCapacity() {
+        if (caches.size == maxCacheSize) {
+            val cacheList = ArrayList(caches.values)
+                    .sorted()
+            for (i in 0 until cacheList.size / 2) {
+                caches.remove(cacheList[i].path)
+            }
+        }
+    }
+
+    @Throws(IOException::class)
+    override fun close() {
+        caches.clear()
+    }
+
+    enum class FindResult {
+        FILE_NOT_FOUND,
+        BAD_SCHEMA,
+        NOT_FOUND,
+        FOUND
+    }
+}

--- a/src/main/java/org/radarbase/output/worker/FileCache.kt
+++ b/src/main/java/org/radarbase/output/worker/FileCache.kt
@@ -118,6 +118,8 @@ class FileCache(
         return result
     }
 
+
+
     fun markError() {
         this.hasError.set(true)
     }

--- a/src/main/java/org/radarbase/output/worker/FileCacheStore.kt
+++ b/src/main/java/org/radarbase/output/worker/FileCacheStore.kt
@@ -36,7 +36,6 @@ import java.util.*
  */
 class FileCacheStore @Throws(IOException::class)
 constructor(private val factory: FileStoreFactory, private val accountant: Accountant) : Flushable, Closeable {
-
     private val tmpDir: TemporaryDirectory
 
     private val caches: MutableMap<Path, FileCache>
@@ -98,7 +97,6 @@ constructor(private val factory: FileStoreFactory, private val accountant: Accou
             fileCache.close()
             NO_CACHE_AND_NO_WRITE
         }
-
     }
 
     @Throws(IOException::class)

--- a/src/main/java/org/radarbase/output/worker/KafkaCleaner.kt
+++ b/src/main/java/org/radarbase/output/worker/KafkaCleaner.kt
@@ -1,0 +1,87 @@
+package org.radarbase.output.worker
+
+import org.radarbase.output.FileStoreFactory
+import org.radarbase.output.accounting.Accountant
+import org.radarbase.output.source.SourceStorageWalker
+import org.slf4j.LoggerFactory
+import java.io.Closeable
+import java.io.IOException
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.LongAdder
+
+class KafkaCleaner(
+        private val fileStoreFactory: FileStoreFactory
+) : Closeable {
+    private val isClosed = AtomicBoolean(false)
+    private val lockManager = fileStoreFactory.remoteLockManager
+    private val sourceStorage = fileStoreFactory.sourceStorage
+    private val excludeTopics: Set<String> = fileStoreFactory.config.topics
+            .mapNotNullTo(HashSet()) { (topic, conf) ->
+                topic.takeIf { conf.excludeFromDelete }
+            }
+
+    val deletedFileCount = LongAdder()
+
+    @Throws(IOException::class, InterruptedException::class)
+    fun process(directoryName: String) {
+        // Get files and directories
+        val absolutePath = Paths.get(directoryName)
+
+        val paths = topicPaths(absolutePath)
+
+        logger.info("{} topics found", paths.size)
+
+        paths.parallelStream()
+                .forEach { p ->
+                    try {
+                        val deleteCount = mapTopic(p)
+                        deletedFileCount.add(deleteCount)
+                    } catch (ex: Exception) {
+                        logger.warn("Failed to map topic", ex)
+                    }
+                }
+    }
+
+    private fun mapTopic(topicPath: Path): Long {
+        if (isClosed.get()) {
+            return 0L
+        }
+
+        val topic = topicPath.fileName.toString()
+
+        return try {
+            lockManager.acquireTopicLock(topic)?.use {
+                Accountant(fileStoreFactory, topic).use { accountant ->
+                    KafkaCleanerWorker(fileStoreFactory, accountant, sourceStorage, isClosed).use { worker ->
+                        worker.deleteOldFiles(topic, topicPath).toLong()
+                                .also {
+                                    if (it > 0) {
+                                        logger.info("Removed {} files in topic {}", it, topic)
+                                    }
+                                }
+                    }
+                }
+            }
+        } catch (ex: IOException) {
+            logger.error("Failed to map files of topic {}", topic, ex)
+            0L
+        } ?: 0L
+    }
+
+
+    private fun topicPaths(path: Path): List<Path> = sourceStorage.walker.walkTopics(path, excludeTopics)
+            .toMutableList()
+            // different services start on different topics to decrease lock contention
+            .also { it.shuffle() }
+
+    override fun close() {
+        isClosed.set(true)
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(KafkaCleaner::class.java)
+    }
+}
+

--- a/src/main/java/org/radarbase/output/worker/KafkaCleanerWorker.kt
+++ b/src/main/java/org/radarbase/output/worker/KafkaCleanerWorker.kt
@@ -1,0 +1,103 @@
+package org.radarbase.output.worker
+
+import org.apache.avro.generic.GenericRecord
+import org.radarbase.output.FileStoreFactory
+import org.radarbase.output.accounting.Accountant
+import org.radarbase.output.source.SourceStorage
+import org.radarbase.output.source.TopicFile
+import org.radarbase.output.util.Timer.time
+import org.radarbase.output.worker.RestructureWorker.Companion.extractRecords
+import org.slf4j.LoggerFactory
+import java.io.Closeable
+import java.io.IOException
+import java.nio.file.Path
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+class KafkaCleanerWorker(
+        private val fileStoreFactory: FileStoreFactory,
+        private val accountant: Accountant,
+        private val sourceStorage: SourceStorage,
+        private val closed: AtomicBoolean
+) : Closeable {
+    private val maxFilesPerTopic: Int = fileStoreFactory.config.worker.maxFilesPerTopic ?: Int.MAX_VALUE
+    private val pathFactory = fileStoreFactory.pathFactory
+    private val reader = sourceStorage.createReader()
+
+    private val deleteThreshold: Instant? = Instant.now().apply { minus(fileStoreFactory.config.cleaner.age.toLong(), ChronoUnit.DAYS) }
+
+    private val cacheStore = ContainsFileCacheStore(fileStoreFactory)
+
+    fun deleteOldFiles(
+            topic: String,
+            topicPath: Path
+    ): Int {
+        val offsets = accountant.offsets.copyForTopic(topic)
+        return sourceStorage.walker.walkRecords(topic, topicPath)
+                .filter { f -> f.lastModified.isBefore(deleteThreshold) &&
+                        // ensure that there is a file with a larger offset also
+                        // processed, so the largest offset is never removed.
+                        offsets.contains(f.range.copy(range = f.range.range.copy(to = f.range.range.to + 1))) }
+                .take(maxFilesPerTopic)
+                .takeWhile { !closed.get() }
+                .count { file ->
+                    if (isExtracted(file)) {
+                        logger.info("Removing {}", file.path)
+                        time("cleaner.delete") {
+                            sourceStorage.delete(file.path)
+                        }
+                        true
+                    } else {
+                        logger.warn("Source file was not completely extracted: {}", file.path)
+                        accountant.remove(file.range)
+                        false
+                    }
+                }
+    }
+
+    private fun isExtracted(file: TopicFile): Boolean {
+        return reader.newInput(file).use { input ->
+            // processing zero-length files may trigger a stall. See:
+            // https://github.com/RADAR-base/Restructure-HDFS-topic/issues/3
+            if (input.length() == 0L) {
+                logger.warn("File {} has zero length, skipping.", file.path)
+                return false
+            }
+            extractRecords(input) { records ->
+                records.all { record -> containsRecord(file.topic, record) }
+            }
+        }
+    }
+
+    private fun containsRecord(topic: String, record: GenericRecord): Boolean {
+        var suffix = 0
+
+        do {
+            val (path) = pathFactory.getRecordOrganization(
+                    topic, record, suffix)
+
+            try {
+                when (cacheStore.contains(path, record)) {
+                    ContainsFileCacheStore.FindResult.FILE_NOT_FOUND -> return false
+                    ContainsFileCacheStore.FindResult.NOT_FOUND -> return false
+                    ContainsFileCacheStore.FindResult.FOUND -> return true
+                    ContainsFileCacheStore.FindResult.BAD_SCHEMA -> suffix += 1  // continue next suffix
+                }
+            } catch (ex: IOException) {
+                logger.error("Failed to read target file for checking data integrity", ex)
+                return false
+            }
+        } while (true)
+    }
+
+    override fun close() {
+        reader.close()
+        cacheStore.close()
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(KafkaCleanerWorker::class.java)
+    }
+}
+

--- a/src/main/java/org/radarbase/output/worker/RadarKafkaRestructure.kt
+++ b/src/main/java/org/radarbase/output/worker/RadarKafkaRestructure.kt
@@ -19,15 +19,12 @@ package org.radarbase.output.worker
 import org.radarbase.output.FileStoreFactory
 import org.radarbase.output.accounting.Accountant
 import org.radarbase.output.accounting.OffsetRangeSet
-import org.radarbase.output.source.TopicFile
 import org.radarbase.output.source.TopicFileList
 import org.slf4j.LoggerFactory
 import java.io.Closeable
 import java.io.IOException
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.time.Instant
-import java.time.temporal.ChronoUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.LongAdder
 
@@ -43,7 +40,7 @@ class RadarKafkaRestructure(
         private val fileStoreFactory: FileStoreFactory
 ): Closeable {
     private val maxFilesPerTopic: Int = fileStoreFactory.config.worker.maxFilesPerTopic ?: Int.MAX_VALUE
-    private val kafkaStorage = fileStoreFactory.sourceStorage
+    private val sourceStorage = fileStoreFactory.sourceStorage
 
     private val lockManager = fileStoreFactory.remoteLockManager
     private val excludeTopics: Set<String> = fileStoreFactory.config.topics
@@ -51,20 +48,11 @@ class RadarKafkaRestructure(
                 topic.takeIf { conf.exclude }
             }
 
-    private val excludeDeleteTopics: Set<String> = fileStoreFactory.config.topics
-            .mapNotNullTo(HashSet()) { (topic, conf) ->
-                topic.takeIf { conf.excludeFromDelete }
-            }
-
-    private val deleteThreshold: Instant? = fileStoreFactory.config.service.deleteAfterDays
-            .takeIf { it > 0 }
-            ?.let { Instant.now().apply { minus(it.toLong(), ChronoUnit.DAYS) } }
-
     private val isClosed = AtomicBoolean(false)
 
     val processedFileCount = LongAdder()
     val processedRecordsCount = LongAdder()
-    val deletedFileCount = LongAdder()
+    private val deletedFileCount = LongAdder()
 
     @Throws(IOException::class, InterruptedException::class)
     fun process(directoryName: String) {
@@ -73,17 +61,16 @@ class RadarKafkaRestructure(
 
         logger.info("Scanning topics...")
 
-        val paths = getTopicPaths(absolutePath)
+        val paths = topicPaths(absolutePath)
 
         logger.info("{} topics found", paths.size)
 
         paths.parallelStream()
                 .forEach { p ->
                     try {
-                        val (fileCount, recordCount, deleteCount) = mapTopic(p)
+                        val (fileCount, recordCount) = mapTopic(p)
                         processedFileCount.add(fileCount)
                         processedRecordsCount.add(recordCount)
-                        deletedFileCount.add(deleteCount.toLong())
                     } catch (ex: Exception) {
                         logger.warn("Failed to map topic", ex)
                     }
@@ -100,13 +87,7 @@ class RadarKafkaRestructure(
         return try {
             lockManager.acquireTopicLock(topic)?.use {
                 Accountant(fileStoreFactory, topic).use { accountant ->
-                    val seenFiles = accountant.offsets
-
-                    val statistics = startWorker(topic, topicPath, accountant, seenFiles)
-                    if (deleteThreshold != null && topic !in excludeDeleteTopics) {
-                        statistics.deleteCount = deleteOldFiles(topic, topicPath, seenFiles)
-                    }
-                    statistics
+                    startWorker(topic, topicPath, accountant, accountant.offsets)
                 }
             }
         } catch (ex: IOException) {
@@ -120,9 +101,9 @@ class RadarKafkaRestructure(
             topicPath: Path,
             accountant: Accountant,
             seenFiles: OffsetRangeSet): ProcessingStatistics {
-        return RestructureWorker(kafkaStorage, accountant, fileStoreFactory, isClosed).use { worker ->
+        return RestructureWorker(sourceStorage, accountant, fileStoreFactory, isClosed).use { worker ->
             try {
-                val topicPaths = TopicFileList(topic, findRecordPaths(topic, topicPath)
+                val topicPaths = TopicFileList(topic, sourceStorage.walker.walkRecords(topic, topicPath)
                         .filter { f -> !seenFiles.contains(f.range) }
                         .take(maxFilesPerTopic)
                         .toList())
@@ -138,57 +119,18 @@ class RadarKafkaRestructure(
         }
     }
 
-    private fun deleteOldFiles(
-            topic: String,
-            topicPath: Path,
-            seenFiles: OffsetRangeSet
-    ) = findRecordPaths(topic, topicPath)
-            .filter { f -> f.lastModified.isBefore(deleteThreshold) &&
-                    // ensure that there is a file with a larger offset also
-                    // processed, so the largest offset is never removed.
-                    seenFiles.contains(f.range.copy(range = f.range.range.copy(to = f.range.range.to + 1))) }
-            .take(maxFilesPerTopic)
-            .map { kafkaStorage.delete(it.path) }
-            .count()
-
-    private fun findTopicPaths(path: Path): Sequence<Path> {
-        val fileStatuses = kafkaStorage.list(path)
-        val avroFile = fileStatuses.find {  !it.isDirectory && it.path.fileName.toString().endsWith(".avro", true) }
-
-        return if (avroFile != null) {
-            sequenceOf(avroFile.path.parent.parent)
-        } else {
-            fileStatuses.asSequence()
-                    .filter { it.isDirectory && it.path.fileName.toString() != "+tmp" }
-                    .flatMap { findTopicPaths(it.path) }
-        }
-    }
-
-    private fun findRecordPaths(topic: String, path: Path): Sequence<TopicFile> = kafkaStorage.list(path)
-            .flatMap { status ->
-                val filename = status.path.fileName.toString()
-                when {
-                    status.isDirectory && filename != "+tmp" -> findRecordPaths(topic, status.path)
-                    filename.endsWith(".avro") -> sequenceOf(TopicFile(topic, status.path, status.lastModified))
-                    else -> emptySequence()
-                }
-            }
-
     override fun close() {
         isClosed.set(true)
     }
 
-    private fun getTopicPaths(path: Path): List<Path> = findTopicPaths(path)
-                .distinct()
-                .filter { it.fileName.toString() !in excludeTopics }
+    private fun topicPaths(root: Path): List<Path> = sourceStorage.walker.walkTopics(root, excludeTopics)
                 .toMutableList()
                 // different services start on different topics to decrease lock contention
                 .also { it.shuffle() }
 
     private data class ProcessingStatistics(
             val fileCount: Long,
-            val recordCount: Long,
-            var deleteCount: Int = 0)
+            val recordCount: Long)
 
     companion object {
         private val logger = LoggerFactory.getLogger(RadarKafkaRestructure::class.java)

--- a/src/test/java/org/radarbase/output/RadarHdfsRestructureTest.kt
+++ b/src/test/java/org/radarbase/output/RadarHdfsRestructureTest.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.radarbase.output.path.ObservationKeyPathFactory
 import org.radarbase.output.path.RecordPathFactory
+import org.radarbase.output.util.TimeUtil.getDate
 
 class RadarHdfsRestructureTest {
     @Test
@@ -43,7 +44,7 @@ class RadarHdfsRestructureTest {
         val valueField1 = GenericRecordBuilder(valueSchema1)
                 .set("time", currentTime.toDouble()).build()
 
-        var date = RecordPathFactory.getDate(keyField, valueField1)
+        var date = getDate(keyField, valueField1)
         var result = factory.getTimeBin(date)
 
         assertEquals("20170502_0700", result)
@@ -53,7 +54,7 @@ class RadarHdfsRestructureTest {
                 .endRecord()
         val valueField2 = GenericRecordBuilder(valueSchema2)
                 .set("a", 0.1).build()
-        date = RecordPathFactory.getDate(keyField, valueField2)
+        date = getDate(keyField, valueField2)
         result = factory.getTimeBin(date)
         assertEquals("20170502_0600", result)
     }

--- a/src/test/java/org/radarbase/output/accounting/OffsetIntervalsTest.kt
+++ b/src/test/java/org/radarbase/output/accounting/OffsetIntervalsTest.kt
@@ -66,4 +66,96 @@ internal class OffsetIntervalsTest {
             assertTrue(contains(2, futureModified))
         }
     }
+
+    @Test
+    fun testRemoveEnd() {
+        OffsetIntervals().run {
+            add(OffsetRangeSet.Range(0, 2, lastModified))
+            assertTrue(contains(1, lastModified))
+            remove(OffsetRangeSet.Range(1, 2, lastModified))
+
+            assertEquals(listOf(
+                    OffsetRangeSet.Range(0, 0, lastModified)
+            ), toList())
+        }
+    }
+
+    @Test
+    fun testRemoveMultiple() {
+        OffsetIntervals().run {
+            add(OffsetRangeSet.Range(0, 2, lastModified))
+            add(OffsetRangeSet.Range(4, 5, lastModified))
+            remove(OffsetRangeSet.Range(2, 4, lastModified))
+
+            assertEquals(listOf(
+                    OffsetRangeSet.Range(0, 1, lastModified),
+                    OffsetRangeSet.Range(5, 5, lastModified)
+            ), toList())
+        }
+    }
+
+
+    @Test
+    fun testRemoveExact() {
+        OffsetIntervals().run {
+            add(OffsetRangeSet.Range(0, 2, lastModified))
+            add(OffsetRangeSet.Range(4, 5, lastModified))
+            add(OffsetRangeSet.Range(7, 8, lastModified))
+            remove(OffsetRangeSet.Range(4, 5, lastModified))
+
+            assertEquals(listOf(
+                    OffsetRangeSet.Range(0, 2, lastModified),
+                    OffsetRangeSet.Range(7, 8, lastModified)
+            ), toList())
+        }
+    }
+
+
+    @Test
+    fun testRemoveExactMultiple() {
+        OffsetIntervals().run {
+            add(OffsetRangeSet.Range(0, 2, lastModified))
+            add(OffsetRangeSet.Range(4, 5, lastModified))
+            add(OffsetRangeSet.Range(7, 8, lastModified))
+            remove(OffsetRangeSet.Range(4, 7, lastModified))
+
+            assertEquals(listOf(
+                    OffsetRangeSet.Range(0, 2, lastModified),
+                    OffsetRangeSet.Range(8, 8, lastModified)
+            ), toList())
+        }
+    }
+
+    @Test
+    fun testRemoveEmpty() {
+        OffsetIntervals().run {
+            remove(OffsetRangeSet.Range(4, 7, lastModified))
+
+            assertEquals(emptyList<OffsetRangeSet.Range>(), toList())
+        }
+    }
+
+    @Test
+    fun testRemoveMiddle() {
+        OffsetIntervals().run {
+            add(OffsetRangeSet.Range(0, 2, lastModified))
+            remove(OffsetRangeSet.Range(1, 1, lastModified))
+            assertEquals(listOf(
+                OffsetRangeSet.Range(0, 0, lastModified),
+                OffsetRangeSet.Range(2, 2, lastModified)
+            ), toList())
+        }
+    }
+
+
+    @Test
+    fun testRemoveStart() {
+        OffsetIntervals().run {
+            add(OffsetRangeSet.Range(0, 2, lastModified))
+            remove(OffsetRangeSet.Range(0, 0, lastModified))
+            assertEquals(listOf(
+                    OffsetRangeSet.Range(1, 2, lastModified)
+            ), toList())
+        }
+    }
 }

--- a/src/test/java/org/radarbase/output/util/TimeUtilTest.kt
+++ b/src/test/java/org/radarbase/output/util/TimeUtilTest.kt
@@ -1,0 +1,16 @@
+package org.radarbase.output.util
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.radarbase.output.util.TimeUtil.toDouble
+import java.time.Instant
+
+internal class TimeUtilTest {
+    @Test
+    fun instantDouble() {
+        val now = System.currentTimeMillis()
+        val instant = Instant.ofEpochMilli(now)
+        val instantDouble = instant.toDouble()
+        assertEquals(now / 1000.0, instantDouble)
+    }
+}


### PR DESCRIPTION
Adds full data integrity check before deleting any files. It does this only by comparing whether data time stamps are present, not the actual data. This does not make it watertight, but it does provide a good indication that the data is in fact present in the output folder. Checks:
- File is older than `age` days
- Offset is recorded in offset management as being extracted
- Each record is checked:
  - Target output file exists and has a matching schema
  - Target output file contains a record with identical timestamp. Not the entire record is compared: data might have been removed due to deduplication. But a time stamp should always be present.

The entire target output file is kept in memory, but only the time stamps, otherwise data checking becomes much too slow.